### PR TITLE
Fix GitHub Actions build failure by removing Docker Hub sync step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,10 +60,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Update repo description
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: meeDamian/sync-readme@v1.0.6
-        with:
-          pass: ${{ secrets.GITHUB_TOKEN }}
-          slug: ${{ github.repository }}
-          description: true


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions build failure that occurred after PR #12 merged GHCR support. The `meeDamian/sync-readme@v1.0.6` action was failing because it's designed for Docker Hub authentication, but the workflow is now configured for GitHub Container Registry (GHCR).

## Problem

- Build failing with: `unable to get access token. Make sure your Docker Hub credentials are correct.`
- The sync-readme action attempts Docker Hub authentication but workflow uses GHCR
- Incompatible authentication methods between Docker Hub and GHCR

## Solution

- **Remove incompatible Docker Hub sync step** - Following 2024-2025 best practices
- **GHCR uses OCI metadata labels** - Already configured via `docker/metadata-action@v5`
- **Repository linking is automatic** - GHCR links packages via `org.opencontainers.image.source` label
- **Eliminates external dependency** - No need for Docker Hub credentials or sync actions

## Research

Investigated current best practices for GitHub Actions Docker workflows:
- GHCR workflows should use OCI-compliant metadata labels (already implemented)
- Docker Hub sync actions are incompatible with GHCR-only workflows
- Modern approach uses automated metadata generation rather than external sync

## Test plan

- [x] Remove problematic sync-readme step
- [ ] Verify PR workflow builds successfully
- [ ] Confirm GHCR package displays metadata correctly
- [ ] Validate no regression in Docker image functionality

🤖 Generated with [Claude Code](https://claude.ai/code)