### PR TITLE
feat: Expand from 16 to 39 tools + fix Pydantic transport bug in find_anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ No more manual data entry, no context switching between apps, no generic genealo
 
 ## Features
 
-### 16 Genealogy Tools
+### 39 Genealogy Tools
 
 #### Search & Retrieval (3 tools)
 - **find_type** - Universal search for any entity type (person, family, event, place, source, citation, media, repository) using Gramps Query Language
 - **find_anything** - Text search across all genealogy data (matches literal text, not logical combinations)
 - **get_type** - Get comprehensive information about specific persons or families by ID
 
-#### Data Management (9 tools)
+#### Data Management (10 tools)
 - **create_person** - Create or update person records
 - **create_family** - Create or update family units
 - **create_event** - Create or update life events
@@ -60,11 +60,38 @@ No more manual data entry, no context switching between apps, no generic genealo
 - **create_note** - Create or update textual notes
 - **create_media** - Create or update media files
 - **create_repository** - Create or update repository records
+- **create_tag** - Create or update tags for organizing records
 
-#### Analysis Tools (4 tools)
+#### Delete Tools (10 tools)
+- **delete_person** - Delete a person by handle
+- **delete_family** - Delete a family by handle
+- **delete_event** - Delete an event by handle
+- **delete_note** - Delete a note by handle
+- **delete_citation** - Delete a citation by handle
+- **delete_source** - Delete a source by handle
+- **delete_place** - Delete a place by handle
+- **delete_repository** - Delete a repository by handle
+- **delete_media** - Delete a media item by handle
+- **delete_tag** - Delete a tag by handle
+
+#### Tag & Media Tools (4 tools)
+- **find_tags** - Find/list all tags in the database
+- **get_media_file** - Get information about a media file (metadata and download URL)
+- **upload_media_file** - Upload a new media file from the local filesystem
+- **update_media_file** - Update an existing media object's file from the local filesystem
+
+#### Analysis Tools (12 tools)
 - **tree_stats** - Get tree statistics and information
 - **get_descendants** - Find all descendants of a person
 - **get_ancestors** - Find all ancestors of a person
+- **get_relations** - Find the relationship between two people (e.g., cousins, uncle/nephew)
+- **get_relations_all** - Find ALL possible relationship paths between two people
+- **get_living** - Check if a person is considered living (for privacy)
+- **get_facts** - Get computed facts and statistics about the tree
+- **get_people_timeline** - Get a timeline of events for a group of people
+- **get_families_timeline** - Get a timeline of events for a group of families
+- **get_event_span** - Calculate time span between two events (e.g., "how old was X when Y happened")
+- **get_types** - Get all valid type values (event types, name types, place types, etc.)
 - **recent_changes** - Track recent modifications to your data
 
 ## Installation
@@ -120,6 +147,23 @@ uv run python -m src.gramps_mcp.server stdio
 ```
 
 The HTTP server will be available at `http://localhost:8000/mcp`, while stdio runs directly in the terminal.
+
+### Media File Uploads
+
+To use the `upload_media_file` and `update_media_file` tools with Docker, you need to mount a volume so the container can access your local files:
+
+```bash
+# Example: Mount a local media folder
+docker run -d --name gramps-mcp -p 8000:8000 \
+  -v /path/to/your/media:/media \
+  -e GRAMPS_API_URL=https://your-gramps-web.com \
+  -e GRAMPS_USERNAME=your-username \
+  -e GRAMPS_PASSWORD=your-password \
+  -e GRAMPS_TREE_ID=your-tree-id \
+  gramps-mcp:latest
+```
+
+Then use `/media/filename.jpg` as the file path in the tool. When running without Docker (using uv directly), you can use absolute paths to any file on your system.
 
 ### Environment Configuration
 

--- a/src/gramps_mcp/client.py
+++ b/src/gramps_mcp/client.py
@@ -234,15 +234,17 @@ class GrampsWebAPIClient:
         json_data = None
 
         if validated_params is not None:
-            params_dict = validated_params.model_dump(exclude_none=True)
             # POST and PUT operations use JSON body, GET operations use query parameters
             if (
                 api_call.method in ["POST", "PUT"]
                 and api_call != ApiCalls.POST_REPORT_FILE
             ):
-                json_data = params_dict
+                # For POST/PUT, include all non-None values (APIs expect complete objects)
+                json_data = validated_params.model_dump(exclude_none=True)
             else:
-                request_params = params_dict
+                # For GET, only include explicitly set values (not defaults)
+                # This prevents sending extra params that APIs may reject
+                request_params = validated_params.model_dump(exclude_unset=True)
 
         # For PUT operations, preserve existing data by merging with changes
         if api_call.method == "PUT" and json_data:
@@ -330,13 +332,27 @@ class GrampsWebAPIClient:
     async def upload_media_file(
         self, file_content: bytes, mime_type: str, tree_id: str = "default"
     ):
-        """Upload a media file to Gramps."""
+        """Upload a new media file to Gramps (creates new media object)."""
         url = self._build_url(tree_id, "media/")
         headers = await self._get_headers()
         headers["Content-Type"] = mime_type
 
         response = await self.auth_manager.client.request(
             method="POST", url=url, content=file_content, headers=headers
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def update_media_file(
+        self, handle: str, file_content: bytes, mime_type: str, tree_id: str = "default"
+    ):
+        """Update an existing media object's file."""
+        url = self._build_url(tree_id, f"media/{handle}/file")
+        headers = await self._get_headers()
+        headers["Content-Type"] = mime_type
+
+        response = await self.auth_manager.client.request(
+            method="PUT", url=url, content=file_content, headers=headers
         )
         response.raise_for_status()
         return response.json()

--- a/src/gramps_mcp/handlers/person_detail_handler.py
+++ b/src/gramps_mcp/handlers/person_detail_handler.py
@@ -47,6 +47,26 @@ async def format_person_detail(client, tree_id: str, handle: str) -> str:
 
     result += f"{name} ({gender_display}) - {gramps_id} - [{handle}]\n"
 
+    # Alternate names (married names, maiden names, etc.)
+    alternate_names = person_data.get("alternate_names", [])
+    if alternate_names:
+        alt_name_strs = []
+        for alt_name in alternate_names:
+            alt_given = alt_name.get("first_name", "")
+            alt_surname_list = alt_name.get("surname_list", [])
+            alt_surname = alt_surname_list[0].get("surname", "") if alt_surname_list else ""
+            alt_full = f"{alt_given} {alt_surname}".strip()
+            alt_type = alt_name.get("type", "")
+            if isinstance(alt_type, dict):
+                alt_type = alt_type.get("string", "") or alt_type.get("_class", "")
+            if alt_full:
+                if alt_type:
+                    alt_name_strs.append(f"{alt_full} ({alt_type})")
+                else:
+                    alt_name_strs.append(alt_full)
+        if alt_name_strs:
+            result += f"Also known as: {', '.join(alt_name_strs)}\n"
+
     # Birth and death from extended data
     extended = person_data.get("extended", {})
     events = extended.get("events", [])

--- a/src/gramps_mcp/handlers/person_handler.py
+++ b/src/gramps_mcp/handlers/person_handler.py
@@ -74,6 +74,26 @@ async def format_person(client, tree_id: str, handle: str) -> str:
         # First line: Name (gender) - gramps_id - [handle]
         result = f"{name} ({gender_display}) - {gramps_id} - [{handle}]\n"
 
+        # Alternate names (married names, maiden names, etc.)
+        alternate_names = person_data.get("alternate_names", [])
+        if alternate_names:
+            alt_name_strs = []
+            for alt_name in alternate_names:
+                alt_given = alt_name.get("first_name", "")
+                alt_surname_list = alt_name.get("surname_list", [])
+                alt_surname = alt_surname_list[0].get("surname", "") if alt_surname_list else ""
+                alt_full = f"{alt_given} {alt_surname}".strip()
+                alt_type = alt_name.get("type", "")
+                if isinstance(alt_type, dict):
+                    alt_type = alt_type.get("string", "") or alt_type.get("_class", "")
+                if alt_full:
+                    if alt_type:
+                        alt_name_strs.append(f"{alt_full} ({alt_type})")
+                    else:
+                        alt_name_strs.append(alt_full)
+            if alt_name_strs:
+                result += f"Also known as: {', '.join(alt_name_strs)}\n"
+
         # Get birth and death events
         extended = person_data.get("extended", {})
         events = extended.get("events", [])

--- a/src/gramps_mcp/models/api_calls.py
+++ b/src/gramps_mcp/models/api_calls.py
@@ -112,8 +112,8 @@ class ApiCalls(Enum):
     GET_LIVING_DATES = ("GET", "living/{handle}/dates")
 
     # ANALYSIS operations - Timelines
-    GET_TIMELINES_PEOPLE = ("GET", "timelines/people")
-    GET_TIMELINES_FAMILIES = ("GET", "timelines/families")
+    GET_TIMELINES_PEOPLE = ("GET", "timelines/people/")
+    GET_TIMELINES_FAMILIES = ("GET", "timelines/families/")
 
     # ANALYSIS operations - Facts
     GET_FACTS = ("GET", "facts/")
@@ -124,9 +124,9 @@ class ApiCalls(Enum):
 
     # MANAGEMENT operations - Types
     GET_TYPES = ("GET", "types/")
-    GET_TYPES_DEFAULT = ("GET", "types/default")
-    GET_TYPES_DEFAULT_DATATYPE = ("GET", "types/default/{datatype}")
-    GET_TYPES_DEFAULT_MAP = ("GET", "types/default/{datatype}/map")
+    GET_TYPES_DEFAULT = ("GET", "types/default/")
+    GET_TYPES_DEFAULT_DATATYPE = ("GET", "types/default/{datatype}/")
+    GET_TYPES_DEFAULT_MAP = ("GET", "types/default/{datatype}/map/")
 
     # REPORTS operations
     GET_REPORTS = ("GET", "reports/")

--- a/src/gramps_mcp/models/api_mapping.py
+++ b/src/gramps_mcp/models/api_mapping.py
@@ -86,7 +86,7 @@ API_CALL_PARAMS: Dict[ApiCalls, Optional[Type[BaseModel]]] = {
     ApiCalls.GET_EVENT: BaseGetSingleParams,
     ApiCalls.PUT_EVENT: EventSaveParams,
     ApiCalls.DELETE_EVENT: None,  # Only needs handle (via URL)
-    ApiCalls.GET_EVENT_SPAN: EventSpanParams,
+    ApiCalls.GET_EVENT_SPAN: None,  # Handles via URL, optional query params don't need validation
     # PLACES operations
     ApiCalls.GET_PLACES: BaseGetMultipleParams,
     ApiCalls.POST_PLACES: PlaceSaveParams,

--- a/src/gramps_mcp/models/parameters/delete_params.py
+++ b/src/gramps_mcp/models/parameters/delete_params.py
@@ -1,0 +1,31 @@
+# gramps-mcp - AI-Powered Genealogy Research & Management
+# Copyright (C) 2025 cabout.me
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Delete parameters for Gramps MCP tools.
+
+Supported API Calls:
+- DELETE_PERSON: Delete a person
+- DELETE_FAMILY: Delete a family
+"""
+
+from pydantic import BaseModel, Field
+
+
+class DeleteParams(BaseModel):
+    """Parameters for deleting an entity."""
+
+    handle: str = Field(..., description="Handle of the entity to delete")

--- a/src/gramps_mcp/models/parameters/family_params.py
+++ b/src/gramps_mcp/models/parameters/family_params.py
@@ -26,9 +26,20 @@ API calls supported in this category:
 - GET_FAMILY_TIMELINE: Get the timeline for all the people in a specific family
 """
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_serializer
+
+
+class ChildReference(BaseModel):
+    """Model for child references in a family's child_ref_list."""
+
+    ref: str = Field(..., description="The handle of the child person")
+    frel: str = Field(default="Birth", description="Father relationship type")
+    mrel: str = Field(default="Birth", description="Mother relationship type")
+    citation_list: List[str] = Field(default_factory=list)
+    note_list: List[str] = Field(default_factory=list)
+    private: bool = Field(default=False)
 
 
 class FamilySaveParams(BaseModel):
@@ -40,7 +51,12 @@ class FamilySaveParams(BaseModel):
     father_handle: Optional[str] = Field(None, description="Father's handle")
     mother_handle: Optional[str] = Field(None, description="Mother's handle")
     child_handles: Optional[List[str]] = Field(
-        None, description="List of child handles"
+        None,
+        description="List of child handles (convenience field, converted to child_ref_list)",
+    )
+    child_ref_list: Optional[List[Dict[str, Any]]] = Field(
+        None,
+        description="List of child references with relationship details",
     )
     event_ref_list: Optional[List[dict]] = Field(
         None, description="List of event references"
@@ -52,6 +68,54 @@ class FamilySaveParams(BaseModel):
     media_list: Optional[List[dict]] = Field(
         None, description="List of media references"
     )
+
+    @model_serializer
+    def serialize_model(self) -> Dict[str, Any]:
+        """
+        Custom serializer that converts child_handles to child_ref_list format.
+
+        The Gramps Web API expects child_ref_list with full reference objects,
+        not a simple list of handles. This serializer performs that conversion.
+        """
+        data = {}
+
+        # Add standard fields
+        if self.handle is not None:
+            data["handle"] = self.handle
+        if self.father_handle is not None:
+            data["father_handle"] = self.father_handle
+        if self.mother_handle is not None:
+            data["mother_handle"] = self.mother_handle
+        if self.event_ref_list is not None:
+            data["event_ref_list"] = self.event_ref_list
+        if self.note_list is not None:
+            data["note_list"] = self.note_list
+        if self.urls is not None:
+            data["urls"] = self.urls
+        if self.media_list is not None:
+            data["media_list"] = self.media_list
+
+        # Convert child_handles to child_ref_list if provided
+        # Reason: The API expects child_ref_list with full reference objects,
+        # but child_handles is more convenient for users to specify
+        if self.child_handles is not None:
+            child_refs = [
+                ChildReference(ref=handle).model_dump()
+                for handle in self.child_handles
+            ]
+            # Merge with any existing child_ref_list
+            if self.child_ref_list is not None:
+                existing_refs = set(
+                    ref.get("ref") for ref in self.child_ref_list if ref.get("ref")
+                )
+                new_refs = [r for r in child_refs if r["ref"] not in existing_refs]
+                data["child_ref_list"] = self.child_ref_list + new_refs
+            else:
+                data["child_ref_list"] = child_refs
+        elif self.child_ref_list is not None:
+            data["child_ref_list"] = self.child_ref_list
+
+        return data
 
 
 class FamilyTimelineParams(BaseModel):

--- a/src/gramps_mcp/models/parameters/media_params.py
+++ b/src/gramps_mcp/models/parameters/media_params.py
@@ -74,3 +74,35 @@ class MediaSaveParams(BaseModel):
             "1=before, 2=after, 3=about, 4=range, 5=span, 6=textonly, 7=from, 8=to)"
         ),
     )
+
+
+class MediaFileUploadParams(BaseModel):
+    """Parameters for uploading a media file from local filesystem."""
+
+    file_path: str = Field(
+        ...,
+        description=(
+            "Absolute path to the file on the local filesystem "
+            "(e.g., '/home/user/photos/grandma.jpg' or 'C:\\Photos\\grandma.jpg')"
+        ),
+    )
+    description: Optional[str] = Field(
+        None,
+        description="Optional description for the media item (used when creating new)",
+    )
+
+
+class MediaFileUpdateParams(BaseModel):
+    """Parameters for updating an existing media object's file."""
+
+    handle: str = Field(
+        ...,
+        description="Handle of the existing media object to update",
+    )
+    file_path: str = Field(
+        ...,
+        description=(
+            "Absolute path to the new file on the local filesystem "
+            "(e.g., '/home/user/photos/grandma_updated.jpg')"
+        ),
+    )

--- a/src/gramps_mcp/models/parameters/people_params.py
+++ b/src/gramps_mcp/models/parameters/people_params.py
@@ -50,6 +50,14 @@ class PersonData(BaseDataModel):
     gender: int = Field(
         ..., ge=0, le=2, description="Gender (0=Female, 1=Male, 2=Unknown)"
     )
+    alternate_names: Optional[List[Dict[str, Any]]] = Field(
+        None,
+        description=(
+            "List of alternate names (married names, maiden names, etc). "
+            "Each name should have the same structure as primary_name with "
+            "first_name, surname_list, and type (e.g., 'Married Name', 'Birth Name')"
+        ),
+    )
     event_ref_list: Optional[List[EventReference]] = Field(
         None, description="List of references to events the person participated in"
     )

--- a/src/gramps_mcp/models/parameters/simple_params.py
+++ b/src/gramps_mcp/models/parameters/simple_params.py
@@ -68,3 +68,9 @@ class SimpleGetParams(BaseModel):
     gramps_id: Optional[str] = Field(
         default=None, description="Gramps ID (e.g., I0001 or F0001)"
     )
+
+
+class EmptyParams(BaseModel):
+    """Empty parameters for tools that don't require any input."""
+
+    pass

--- a/src/gramps_mcp/server.py
+++ b/src/gramps_mcp/server.py
@@ -43,12 +43,21 @@ from .models.parameters.people_params import PersonData
 from .models.parameters.place_params import PlaceSaveParams
 from .models.parameters.repository_params import RepositoryData
 from .models.parameters.simple_params import (
+    EmptyParams,
     SimpleFindParams,
     SimpleGetParams,
     SimpleSearchParams,
 )
 from .models.parameters.source_params import SourceSaveParams
 from .models.parameters.transactions_params import TransactionHistoryParams
+from .models.parameters.delete_params import DeleteParams
+from .models.parameters.relations_params import RelationParams
+from .models.parameters.tag_params import TagSaveParams, TagSearchParams
+from .models.parameters.living_params import LivingParams
+from .models.parameters.facts_params import FactsParams
+from .models.parameters.timeline_params import PeopleTimelineParams, FamiliesTimelineParams
+from .models.parameters.media_params import MediaFileUploadParams, MediaFileUpdateParams
+from .models.parameters.event_params import EventSpanParams
 
 # Import all tool functions
 from .tools import (
@@ -61,11 +70,34 @@ from .tools import (
     create_place_tool,
     create_repository_tool,
     create_source_tool,
+    create_tag_tool,
+    delete_citation_tool,
+    delete_event_tool,
+    delete_family_tool,
+    delete_media_tool,
+    delete_note_tool,
+    delete_person_tool,
+    delete_place_tool,
+    delete_repository_tool,
+    delete_source_tool,
+    delete_tag_tool,
     find_anything_tool,
+    find_tags_tool,
     get_ancestors_tool,
     get_descendants_tool,
+    get_facts_tool,
+    get_families_timeline_tool,
+    get_living_tool,
+    get_media_file_tool,
+    get_people_timeline_tool,
     get_recent_changes_tool,
+    get_relations_all_tool,
+    get_relations_tool,
     get_tree_info_tool,
+    get_event_span_tool,
+    get_types_tool,
+    update_media_file_tool,
+    upload_media_file_tool,
 )
 from .tools.search_basic import find_type_tool
 from .tools.search_details import get_type_tool
@@ -178,6 +210,52 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "schema": RepositoryData,
         "handler": create_repository_tool,
     },
+    # Delete Tools
+    "delete_person": {
+        "description": "Delete a person by handle",
+        "schema": DeleteParams,
+        "handler": delete_person_tool,
+    },
+    "delete_family": {
+        "description": "Delete a family by handle",
+        "schema": DeleteParams,
+        "handler": delete_family_tool,
+    },
+    "delete_event": {
+        "description": "Delete an event by handle",
+        "schema": DeleteParams,
+        "handler": delete_event_tool,
+    },
+    "delete_note": {
+        "description": "Delete a note by handle",
+        "schema": DeleteParams,
+        "handler": delete_note_tool,
+    },
+    "delete_citation": {
+        "description": "Delete a citation by handle",
+        "schema": DeleteParams,
+        "handler": delete_citation_tool,
+    },
+    "delete_source": {
+        "description": "Delete a source by handle",
+        "schema": DeleteParams,
+        "handler": delete_source_tool,
+    },
+    "delete_place": {
+        "description": "Delete a place by handle",
+        "schema": DeleteParams,
+        "handler": delete_place_tool,
+    },
+    "delete_repository": {
+        "description": "Delete a repository by handle",
+        "schema": DeleteParams,
+        "handler": delete_repository_tool,
+    },
+    "delete_media": {
+        "description": "Delete a media item by handle",
+        "schema": DeleteParams,
+        "handler": delete_media_tool,
+    },
     # Analysis Tools
     "tree_stats": {
         "description": (
@@ -208,6 +286,92 @@ TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "schema": TransactionHistoryParams,
         "handler": get_recent_changes_tool,
     },
+    "get_relations": {
+        "description": "Find the relationship between two people (e.g., cousins, uncle/nephew)",
+        "schema": RelationParams,
+        "handler": get_relations_tool,
+    },
+    "get_relations_all": {
+        "description": "Find ALL possible relationship paths between two people",
+        "schema": RelationParams,
+        "handler": get_relations_all_tool,
+    },
+    # Living & Facts Tools
+    "get_living": {
+        "description": "Check if a person is considered living (for privacy purposes)",
+        "schema": LivingParams,
+        "handler": get_living_tool,
+    },
+    "get_facts": {
+        "description": "Get computed facts and statistics about the family tree",
+        "schema": FactsParams,
+        "handler": get_facts_tool,
+    },
+    # Tag Tools
+    "find_tags": {
+        "description": "Find/list all tags in the database",
+        "schema": TagSearchParams,
+        "handler": find_tags_tool,
+    },
+    "create_tag": {
+        "description": "Create or update a tag for organizing records",
+        "schema": TagSaveParams,
+        "handler": create_tag_tool,
+    },
+    "delete_tag": {
+        "description": "Delete a tag by handle",
+        "schema": DeleteParams,
+        "handler": delete_tag_tool,
+    },
+    # Timeline Tools
+    "get_people_timeline": {
+        "description": "Get a timeline of events for a group of people",
+        "schema": PeopleTimelineParams,
+        "handler": get_people_timeline_tool,
+    },
+    "get_families_timeline": {
+        "description": "Get a timeline of events for a group of families",
+        "schema": FamiliesTimelineParams,
+        "handler": get_families_timeline_tool,
+    },
+    # Media File Tools
+    "get_media_file": {
+        "description": "Get information about a media file (metadata and download URL)",
+        "schema": DeleteParams,
+        "handler": get_media_file_tool,
+    },
+    "upload_media_file": {
+        "description": (
+            "Upload a new media file from the local filesystem - "
+            "creates a new media object with the file content"
+        ),
+        "schema": MediaFileUploadParams,
+        "handler": upload_media_file_tool,
+    },
+    "update_media_file": {
+        "description": (
+            "Update an existing media object's file from the local filesystem - "
+            "replaces the file content for an existing media object"
+        ),
+        "schema": MediaFileUpdateParams,
+        "handler": update_media_file_tool,
+    },
+    # Event & Type Tools
+    "get_event_span": {
+        "description": (
+            "Calculate time span between two events - useful for 'how old was X when Y happened' queries"
+        ),
+        "schema": EventSpanParams,
+        "handler": get_event_span_tool,
+    },
+    "get_types": {
+        "description": (
+            "Get all valid type values (event types, name types, place types, etc.) - "
+            "reference for creating records"
+        ),
+        "schema": EmptyParams,
+        "handler": get_types_tool,
+    },
 }
 
 
@@ -229,13 +393,23 @@ def register_tools():
         description = tool_config["description"]
 
         # Create the async handler function with proper schema annotation
-        async def create_handler(arguments, handler=handler_func):
-            return await handler(arguments.model_dump())
+        # Pass the validated Pydantic model directly to the handler
+        # Handlers will check if they receive a BaseModel and skip re-validation
+        if schema == EmptyParams:
+            # For tools with no parameters, make arguments optional
+            async def create_handler(arguments: Optional[EmptyParams] = None, handler=handler_func):
+                return await handler(arguments or {})
+
+            create_handler.__annotations__ = {"arguments": Optional[EmptyParams]}
+        else:
+            async def create_handler(arguments, handler=handler_func):
+                return await handler(arguments)
+
+            create_handler.__annotations__ = {"arguments": schema}
 
         # Set proper metadata
         create_handler.__name__ = tool_name
         create_handler.__doc__ = description
-        create_handler.__annotations__ = {"arguments": schema}
 
         # Register with FastMCP
         app.tool(description=description)(create_handler)
@@ -294,7 +468,7 @@ async def root(request):
             "version": "1.0.0",
             "description": "MCP server for Gramps Web API genealogy operations",
             "mcp_endpoint": "/mcp",
-            "tools_count": 16,
+            "tools_count": 39,
         }
     )
 
@@ -305,7 +479,7 @@ async def health_check(request):
     from starlette.responses import JSONResponse
 
     return JSONResponse(
-        {"status": "healthy", "service": "Gramps MCP Server", "tools": 16}
+        {"status": "healthy", "service": "Gramps MCP Server", "tools": 39}
     )
 
 

--- a/src/gramps_mcp/tools.py
+++ b/src/gramps_mcp/tools.py
@@ -33,6 +33,13 @@ from .tools import (
     create_place_tool,
     create_repository_tool,
     create_source_tool,
+    # Delete Tools
+    delete_citation_tool,
+    delete_event_tool,
+    delete_family_tool,
+    delete_note_tool,
+    delete_person_tool,
+    delete_source_tool,
     find_anything_tool,
     find_citation_tool,
     find_event_tool,
@@ -48,6 +55,7 @@ from .tools import (
     get_family_tool,
     get_person_tool,
     get_recent_changes_tool,
+    get_relations_tool,
     # Analysis Tools
     get_tree_info_tool,
 )
@@ -76,9 +84,17 @@ __all__ = [
     "create_note_tool",
     "create_media_tool",
     "create_repository_tool",
+    # Delete Tools
+    "delete_person_tool",
+    "delete_family_tool",
+    "delete_event_tool",
+    "delete_note_tool",
+    "delete_citation_tool",
+    "delete_source_tool",
     # Analysis Tools
     "get_tree_info_tool",
     "get_descendants_tool",
     "get_ancestors_tool",
     "get_recent_changes_tool",
+    "get_relations_tool",
 ]

--- a/src/gramps_mcp/tools/__init__.py
+++ b/src/gramps_mcp/tools/__init__.py
@@ -17,22 +17,29 @@
 """
 Unified interface for all MCP tools.
 
-This module exports all 24 genealogy tools organized by category:
-- Search & Discovery Tools (10)
-- Data Management Tools (9)
-- Analysis Tools (5)
+This module exports all 39 genealogy tools organized by category:
+- Search & Discovery Tools (3)
+- Data Management Tools (9 create + 10 delete + 4 tag/media + 2 upload = 25)
+- Analysis Tools (11)
 """
 
-# Search & Discovery Tools (10 tools)
-# Analysis Tools (4 tools)
+# Analysis Tools (11 tools)
 from .analysis import (
     get_ancestors_tool,
     get_descendants_tool,
+    get_event_span_tool,
+    get_facts_tool,
+    get_families_timeline_tool,
+    get_living_tool,
+    get_people_timeline_tool,
     get_recent_changes_tool,
+    get_relations_all_tool,
+    get_relations_tool,
     get_tree_info_tool,
+    get_types_tool,
 )
 
-# Data Management Tools (9 tools)
+# Data Management Tools (25 tools)
 from .data_management import (
     create_citation_tool,
     create_event_tool,
@@ -43,6 +50,21 @@ from .data_management import (
     create_place_tool,
     create_repository_tool,
     create_source_tool,
+    create_tag_tool,
+    delete_citation_tool,
+    delete_event_tool,
+    delete_family_tool,
+    delete_media_tool,
+    delete_note_tool,
+    delete_person_tool,
+    delete_place_tool,
+    delete_repository_tool,
+    delete_source_tool,
+    delete_tag_tool,
+    find_tags_tool,
+    get_media_file_tool,
+    update_media_file_tool,
+    upload_media_file_tool,
 )
 from .search_basic import (
     find_anything_tool,
@@ -74,7 +96,7 @@ __all__ = [
     "find_anything_tool",
     "get_person_tool",
     "get_family_tool",
-    # Data Management Tools
+    # Data Management Tools - Create
     "create_person_tool",
     "create_family_tool",
     "create_event_tool",
@@ -84,9 +106,34 @@ __all__ = [
     "create_note_tool",
     "create_media_tool",
     "create_repository_tool",
+    "create_tag_tool",
+    # Data Management Tools - Delete
+    "delete_person_tool",
+    "delete_family_tool",
+    "delete_event_tool",
+    "delete_note_tool",
+    "delete_citation_tool",
+    "delete_source_tool",
+    "delete_place_tool",
+    "delete_repository_tool",
+    "delete_media_tool",
+    "delete_tag_tool",
+    # Data Management Tools - Tags & Media
+    "find_tags_tool",
+    "get_media_file_tool",
+    "upload_media_file_tool",
+    "update_media_file_tool",
     # Analysis Tools
     "get_tree_info_tool",
     "get_descendants_tool",
     "get_ancestors_tool",
     "get_recent_changes_tool",
+    "get_relations_tool",
+    "get_relations_all_tool",
+    "get_living_tool",
+    "get_facts_tool",
+    "get_people_timeline_tool",
+    "get_families_timeline_tool",
+    "get_event_span_tool",
+    "get_types_tool",
 ]

--- a/src/gramps_mcp/tools/analysis.py
+++ b/src/gramps_mcp/tools/analysis.py
@@ -38,6 +38,15 @@ from .search_basic import with_client
 logger = logging.getLogger(__name__)
 
 
+def _get_arg(arguments, key, default=None):
+    """Get argument value from either dict or BaseModel."""
+    from pydantic import BaseModel
+
+    if isinstance(arguments, BaseModel):
+        return getattr(arguments, key, default)
+    return arguments.get(key, default)
+
+
 def _format_error_response(error: Exception, operation: str) -> List[TextContent]:
     """Format error into user-friendly MCP response."""
     if isinstance(error, GrampsAPIError):
@@ -180,14 +189,14 @@ async def _wait_for_task_completion(
 
 
 @with_client
-async def get_descendants_tool(client, arguments: Dict) -> List[TextContent]:
+async def get_descendants_tool(client, arguments) -> List[TextContent]:
     """
     Find all descendants of a person.
     """
     try:
-        # Extract arguments directly
-        gramps_id = arguments.get("gramps_id")
-        max_generations = arguments.get("max_generations")
+        # Extract arguments (handles both dict and BaseModel)
+        gramps_id = _get_arg(arguments, "gramps_id")
+        max_generations = _get_arg(arguments, "max_generations")
 
         if not gramps_id:
             raise ValueError("gramps_id is required")
@@ -273,14 +282,14 @@ async def get_descendants_tool(client, arguments: Dict) -> List[TextContent]:
 
 
 @with_client
-async def get_ancestors_tool(client, arguments: Dict) -> List[TextContent]:
+async def get_ancestors_tool(client, arguments) -> List[TextContent]:
     """
     Find all ancestors of a person.
     """
     try:
-        # Extract arguments directly
-        gramps_id = arguments.get("gramps_id")
-        max_generations = arguments.get("max_generations")
+        # Extract arguments (handles both dict and BaseModel)
+        gramps_id = _get_arg(arguments, "gramps_id")
+        max_generations = _get_arg(arguments, "max_generations")
 
         if not gramps_id:
             raise ValueError("gramps_id is required")
@@ -428,7 +437,59 @@ def _format_tree_info(tree_info: Dict) -> str:
 
 
 @with_client
-async def get_tree_info_tool(client, _arguments: Dict) -> List[TextContent]:
+async def get_relations_tool(client, arguments) -> List[TextContent]:
+    """
+    Find the relationship between two people.
+    """
+    try:
+        handle1 = _get_arg(arguments, "handle1")
+        handle2 = _get_arg(arguments, "handle2")
+
+        if not handle1 or not handle2:
+            raise ValueError("Both handle1 and handle2 are required")
+
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Get relationship using the API
+        relations = await client.make_api_call(
+            api_call=ApiCalls.GET_RELATIONS,
+            params=None,
+            tree_id=tree_id,
+            handle1=handle1,
+            handle2=handle2,
+        )
+
+        if not relations:
+            return [TextContent(type="text", text="No relationship found between these two people.")]
+
+        # Format the relationship result
+        # API returns: {"distance_common_origin": N, "distance_common_other": M, "relationship_string": "..."}
+        result = "## Relationship Found\n\n"
+
+        if isinstance(relations, dict):
+            relationship = relations.get("relationship_string", "Unknown")
+            dist_origin = relations.get("distance_common_origin")
+            dist_other = relations.get("distance_common_other")
+
+            result += f"**Relationship:** {relationship}\n"
+
+            if dist_origin is not None and dist_other is not None:
+                total_distance = dist_origin + dist_other
+                result += f"**Total Distance:** {total_distance} generations\n"
+                result += f"  - From person 1 to common ancestor: {dist_origin}\n"
+                result += f"  - From common ancestor to person 2: {dist_other}\n"
+        else:
+            result += str(relations)
+
+        return [TextContent(type="text", text=result)]
+
+    except Exception as e:
+        return _format_error_response(e, "relationship lookup")
+
+
+@with_client
+async def get_tree_info_tool(client, _arguments) -> List[TextContent]:
     """
     Get information about a specific tree including statistics.
 
@@ -449,3 +510,436 @@ async def get_tree_info_tool(client, _arguments: Dict) -> List[TextContent]:
 
     except Exception as e:
         return _format_error_response(e, "tree information retrieval")
+
+
+# ============================================================================
+# Living Status Tools
+# ============================================================================
+
+
+@with_client
+async def get_living_tool(client, arguments) -> List[TextContent]:
+    """
+    Check if a person is considered living (for privacy purposes).
+    """
+    try:
+        handle = _get_arg(arguments, "handle")
+
+        if not handle:
+            raise ValueError("handle is required")
+
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Get living status
+        result = await client.make_api_call(
+            api_call=ApiCalls.GET_LIVING,
+            params=None,
+            tree_id=tree_id,
+            handle=handle,
+        )
+
+        # Format response
+        is_living = result.get("living", False) if isinstance(result, dict) else result
+        status = "LIVING" if is_living else "DECEASED"
+
+        return [
+            TextContent(
+                type="text",
+                text=f"**Living Status:** {status}\n\nHandle: `{handle}`",
+            )
+        ]
+
+    except Exception as e:
+        return _format_error_response(e, "living status check")
+
+
+# ============================================================================
+# Facts Tools
+# ============================================================================
+
+
+@with_client
+async def get_facts_tool(client, arguments) -> List[TextContent]:
+    """
+    Get computed facts and statistics about the family tree.
+    """
+    try:
+        from ..models.parameters.facts_params import FactsParams
+
+        # Extract only explicitly provided arguments (not defaults)
+        # to avoid sending extra params the API rejects
+        if isinstance(arguments, FactsParams):
+            # Get only user-provided values
+            params_dict = arguments.model_dump(exclude_unset=True)
+        elif isinstance(arguments, dict):
+            params_dict = {k: v for k, v in arguments.items() if v is not None}
+        else:
+            params_dict = {}
+
+        # Only create params if there are explicit values to send
+        params = FactsParams(**params_dict) if params_dict else None
+
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Get facts
+        facts = await client.make_api_call(
+            api_call=ApiCalls.GET_FACTS,
+            params=params,
+            tree_id=tree_id,
+        )
+
+        # Format response
+        if not facts:
+            return [TextContent(type="text", text="No facts available.")]
+
+        result = "# Tree Facts\n\n"
+
+        if isinstance(facts, dict):
+            for key, value in facts.items():
+                if isinstance(value, dict):
+                    result += f"## {key.replace('_', ' ').title()}\n"
+                    for sub_key, sub_value in value.items():
+                        result += f"- **{sub_key}:** {sub_value}\n"
+                    result += "\n"
+                elif isinstance(value, list):
+                    result += f"## {key.replace('_', ' ').title()}\n"
+                    for item in value[:10]:  # Limit to first 10
+                        result += f"- {item}\n"
+                    result += "\n"
+                else:
+                    result += f"- **{key.replace('_', ' ').title()}:** {value}\n"
+        else:
+            result += str(facts)
+
+        return [TextContent(type="text", text=result)]
+
+    except Exception as e:
+        return _format_error_response(e, "facts retrieval")
+
+
+# ============================================================================
+# Relations All Tool
+# ============================================================================
+
+
+@with_client
+async def get_relations_all_tool(client, arguments) -> List[TextContent]:
+    """
+    Find ALL possible relationship paths between two people.
+    """
+    try:
+        handle1 = _get_arg(arguments, "handle1")
+        handle2 = _get_arg(arguments, "handle2")
+
+        if not handle1 or not handle2:
+            raise ValueError("Both handle1 and handle2 are required")
+
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Get all relationships
+        relations = await client.make_api_call(
+            api_call=ApiCalls.GET_RELATIONS_ALL,
+            params=None,
+            tree_id=tree_id,
+            handle1=handle1,
+            handle2=handle2,
+        )
+
+        if not relations:
+            return [
+                TextContent(
+                    type="text",
+                    text="No relationships found between these two people.",
+                )
+            ]
+
+        # Format all relationships
+        result = "## All Relationship Paths\n\n"
+
+        if isinstance(relations, list):
+            for i, rel in enumerate(relations, 1):
+                relationship = rel.get("relationship_string", "Unknown")
+                dist_origin = rel.get("distance_common_origin")
+                dist_other = rel.get("distance_common_other")
+
+                result += f"**Path {i}:** {relationship}\n"
+                if dist_origin is not None and dist_other is not None:
+                    result += f"  - Distance: {dist_origin + dist_other} generations\n"
+                result += "\n"
+        else:
+            result += str(relations)
+
+        return [TextContent(type="text", text=result)]
+
+    except Exception as e:
+        return _format_error_response(e, "all relationships lookup")
+
+
+# ============================================================================
+# Timeline Tools
+# ============================================================================
+
+
+@with_client
+async def get_people_timeline_tool(client, arguments) -> List[TextContent]:
+    """
+    Get a timeline of events for a group of people.
+    """
+    try:
+        from ..models.parameters.timeline_params import PeopleTimelineParams
+
+        # Extract only explicitly provided arguments (not defaults)
+        # to avoid sending extra params the API rejects
+        if isinstance(arguments, PeopleTimelineParams):
+            params_dict = arguments.model_dump(exclude_unset=True)
+        elif isinstance(arguments, dict):
+            params_dict = {k: v for k, v in arguments.items() if v is not None}
+        else:
+            params_dict = {}
+
+        # Only create params if there are explicit values to send
+        params = PeopleTimelineParams(**params_dict) if params_dict else None
+
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Get timeline
+        timeline = await client.make_api_call(
+            api_call=ApiCalls.GET_TIMELINES_PEOPLE,
+            params=params,
+            tree_id=tree_id,
+        )
+
+        if not timeline:
+            return [TextContent(type="text", text="No timeline events found.")]
+
+        # Format timeline
+        result = "# People Timeline\n\n"
+
+        events = timeline if isinstance(timeline, list) else timeline.get("data", [])
+        for event in events[:50]:  # Limit output
+            # Date can be a string or dict depending on API version
+            date = event.get("date", "Unknown date")
+            if isinstance(date, dict):
+                date_str = date.get("sortval", date.get("text", "Unknown date"))
+            else:
+                date_str = str(date) if date else "Unknown date"
+
+            event_type = event.get("type", event.get("label", "Event"))
+            description = event.get("description", "")
+            age = event.get("age", "")
+
+            # Person info - the person field is a dict with name_display, etc.
+            person = event.get("person", {})
+            if isinstance(person, dict):
+                person_name = person.get("name_display", person.get("name", ""))
+            else:
+                person_name = ""
+
+            result += f"- **{date_str}** - {event_type}"
+            if description:
+                result += f": {description}"
+            if person_name:
+                result += f" ({person_name})"
+            if age:
+                result += f" [age: {age}]"
+            result += "\n"
+
+        return [TextContent(type="text", text=result)]
+
+    except Exception as e:
+        return _format_error_response(e, "people timeline retrieval")
+
+
+@with_client
+async def get_families_timeline_tool(client, arguments) -> List[TextContent]:
+    """
+    Get a timeline of events for a group of families.
+    """
+    try:
+        from ..models.parameters.timeline_params import FamiliesTimelineParams
+
+        # Extract only explicitly provided arguments (not defaults)
+        # to avoid sending extra params the API rejects
+        if isinstance(arguments, FamiliesTimelineParams):
+            params_dict = arguments.model_dump(exclude_unset=True)
+        elif isinstance(arguments, dict):
+            params_dict = {k: v for k, v in arguments.items() if v is not None}
+        else:
+            params_dict = {}
+
+        # Only create params if there are explicit values to send
+        params = FamiliesTimelineParams(**params_dict) if params_dict else None
+
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Get timeline
+        timeline = await client.make_api_call(
+            api_call=ApiCalls.GET_TIMELINES_FAMILIES,
+            params=params,
+            tree_id=tree_id,
+        )
+
+        if not timeline:
+            return [TextContent(type="text", text="No family timeline events found.")]
+
+        # Format timeline
+        result = "# Families Timeline\n\n"
+
+        events = timeline if isinstance(timeline, list) else timeline.get("data", [])
+        for event in events[:50]:  # Limit output
+            # Date can be a string or dict depending on API version
+            date = event.get("date", "Unknown date")
+            if isinstance(date, dict):
+                date_str = date.get("sortval", date.get("text", "Unknown date"))
+            else:
+                date_str = str(date) if date else "Unknown date"
+
+            event_type = event.get("type", event.get("label", "Event"))
+            description = event.get("description", "")
+            age = event.get("age", "")
+
+            # Person info if available
+            person = event.get("person", {})
+            if isinstance(person, dict):
+                person_name = person.get("name_display", person.get("name", ""))
+            else:
+                person_name = ""
+
+            result += f"- **{date_str}** - {event_type}"
+            if description:
+                result += f": {description}"
+            if person_name:
+                result += f" ({person_name})"
+            if age:
+                result += f" [age: {age}]"
+            result += "\n"
+
+        return [TextContent(type="text", text=result)]
+
+    except Exception as e:
+        return _format_error_response(e, "families timeline retrieval")
+
+
+# ============================================================================
+# Event Span Tool
+# ============================================================================
+
+
+@with_client
+async def get_event_span_tool(client, arguments) -> List[TextContent]:
+    """
+    Calculate the time span between two events.
+
+    Useful for questions like "How old was X when Y happened?" or
+    "How long between marriage and first child?"
+    """
+    try:
+        handle1 = _get_arg(arguments, "handle1")
+        handle2 = _get_arg(arguments, "handle2")
+        precision = _get_arg(arguments, "precision", 2)
+        as_age = _get_arg(arguments, "as_age", True)
+
+        if not handle1 or not handle2:
+            raise ValueError("Both handle1 and handle2 are required")
+
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Build query params - only include if explicitly set to non-default values
+        params = {}
+        if precision is not None and precision != 2:
+            params["precision"] = precision
+        if as_age is not None and not as_age:
+            params["as_age"] = as_age
+
+        # Get event span
+        result = await client.make_api_call(
+            api_call=ApiCalls.GET_EVENT_SPAN,
+            params=params if params else None,
+            tree_id=tree_id,
+            handle1=handle1,
+            handle2=handle2,
+        )
+
+        span = result.get("span", "unknown") if isinstance(result, dict) else "unknown"
+
+        response = f"## Time Span Between Events\n\n"
+        response += f"**Event 1:** `{handle1}`\n"
+        response += f"**Event 2:** `{handle2}`\n"
+        response += f"**Span:** {span}\n"
+
+        if span == "unknown":
+            response += "\n*Note: Span could not be calculated. This usually means one or both events don't have complete dates.*"
+
+        return [TextContent(type="text", text=response)]
+
+    except Exception as e:
+        return _format_error_response(e, "event span calculation")
+
+
+# ============================================================================
+# Types Reference Tool
+# ============================================================================
+
+
+@with_client
+async def get_types_tool(client, arguments) -> List[TextContent]:
+    """
+    Get all valid type values for Gramps records.
+
+    Returns valid values for event types, name types, place types,
+    note types, and more. Useful as a reference when creating records.
+    """
+    try:
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Get default types
+        result = await client.make_api_call(
+            api_call=ApiCalls.GET_TYPES_DEFAULT,
+            params=None,
+            tree_id=tree_id,
+        )
+
+        if not result:
+            return [TextContent(type="text", text="No type information available.")]
+
+        response = "# Gramps Type Reference\n\n"
+        response += "Valid values for each record type:\n\n"
+
+        # Format each type category
+        type_categories = [
+            ("event_types", "Event Types"),
+            ("name_types", "Name Types"),
+            ("place_types", "Place Types"),
+            ("note_types", "Note Types"),
+            ("family_relation_types", "Family Relation Types"),
+            ("gender_types", "Gender Types"),
+            ("repository_types", "Repository Types"),
+            ("source_media_types", "Source Media Types"),
+            ("name_origin_types", "Name Origin Types"),
+            ("event_role_types", "Event Role Types"),
+            ("child_reference_types", "Child Reference Types"),
+            ("attribute_types", "Attribute Types"),
+            ("url_types", "URL Types"),
+        ]
+
+        for key, label in type_categories:
+            if key in result:
+                values = result[key]
+                response += f"## {label}\n"
+                # Format as comma-separated list, max 8 per line
+                for i in range(0, len(values), 8):
+                    chunk = values[i:i+8]
+                    response += ", ".join(chunk) + "\n"
+                response += "\n"
+
+        return [TextContent(type="text", text=response)]
+
+    except Exception as e:
+        return _format_error_response(e, "types retrieval")

--- a/src/gramps_mcp/tools/data_management.py
+++ b/src/gramps_mcp/tools/data_management.py
@@ -17,11 +17,13 @@
 """
 Data management MCP tools for genealogy operations.
 
-This module contains 8 CRUD tools for creating and updating people, families,
-events, places, sources, citations, notes, and media records.
+This module contains CRUD tools for creating and updating people, families,
+events, places, sources, citations, notes, media records, and file uploads.
 """
 
 import logging
+import mimetypes
+import os
 from typing import Dict, List
 
 from mcp.types import TextContent
@@ -84,13 +86,22 @@ def _extract_entity_data(result, entity_type: str = None):
     )
 
 
+def _validate_params(arguments, param_class):
+    """Validate parameters - skip if already a validated Pydantic model."""
+    from pydantic import BaseModel
+
+    if isinstance(arguments, BaseModel):
+        return arguments
+    return param_class(**arguments)
+
+
 async def _handle_crud_operation(
     params, entity_type: str, post_api_call, put_api_call, param_class
 ) -> List[TextContent]:
     """Common helper for create/update operations."""
     try:
-        # Validate parameters
-        validated_params = param_class(**params)
+        # Validate parameters - skip if already a validated Pydantic model
+        validated_params = _validate_params(params, param_class)
 
         # Get tree_id from settings
         settings = get_settings()
@@ -195,13 +206,13 @@ async def create_person_tool(arguments: Dict) -> List[TextContent]:
     )
 
 
-async def create_family_tool(arguments: Dict) -> List[TextContent]:
+async def create_family_tool(arguments) -> List[TextContent]:
     """
     Create or update family unit including member relationships.
     """
     try:
-        # Validate parameters
-        params = FamilySaveParams(**arguments)
+        # Validate parameters - handles both dict and BaseModel inputs
+        params = _validate_params(arguments, FamilySaveParams)
 
         # Get tree_id from settings
         settings = get_settings()
@@ -294,19 +305,27 @@ async def create_note_tool(arguments: Dict) -> List[TextContent]:
     )
 
 
-async def create_media_tool(arguments: Dict) -> List[TextContent]:
+async def create_media_tool(arguments) -> List[TextContent]:
     """
     Create or update media files including object associations.
     """
     import mimetypes
     import os
+    from pydantic import BaseModel
 
     try:
+        # Handle both dict and BaseModel inputs
+        if isinstance(arguments, BaseModel):
+            # Convert to dict for processing
+            args_dict = arguments.model_dump()
+        else:
+            args_dict = arguments
+
         # Extract file_location separately (not part of MediaSaveParams)
-        file_location = arguments.get("file_location")
+        file_location = args_dict.get("file_location")
 
         # All other arguments are for metadata
-        media_params = {k: v for k, v in arguments.items() if k != "file_location"}
+        media_params = {k: v for k, v in args_dict.items() if k != "file_location"}
         params = MediaSaveParams(**media_params) if media_params else None
 
         settings = get_settings()
@@ -380,31 +399,29 @@ async def create_media_tool(arguments: Dict) -> List[TextContent]:
         return _format_error_response(e, "media save")
 
 
-async def create_repository_tool(arguments: Dict) -> List[TextContent]:
+async def create_repository_tool(arguments) -> List[TextContent]:
     """
     Create or update repository information.
     """
     try:
-        # Let Pydantic model handle parameter validation
+        # Validate parameters - handles both dict and BaseModel inputs
+        params = _validate_params(arguments, RepositoryData)
 
         # Assert required parameters
-        if not arguments.get("name"):
+        if not params.name:
             return [
                 TextContent(
                     type="text",
                     text="Error: 'name' parameter is required for repository",
                 )
             ]
-        if not arguments.get("type"):
+        if not params.type:
             return [
                 TextContent(
                     type="text",
                     text="Error: 'type' parameter is required for repository",
                 )
             ]
-
-        # Validate parameters
-        params = RepositoryData(**arguments)
 
         # Get tree_id from settings
         settings = get_settings()
@@ -442,3 +459,602 @@ async def create_repository_tool(arguments: Dict) -> List[TextContent]:
 
     except Exception as e:
         return _format_error_response(e, "repository save")
+
+
+# ============================================================================
+# Delete Tools (2 tools)
+# ============================================================================
+
+
+async def delete_person_tool(arguments) -> List[TextContent]:
+    """Delete a person by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_PERSON,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted person with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "person delete")
+
+
+async def delete_family_tool(arguments) -> List[TextContent]:
+    """Delete a family by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_FAMILY,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted family with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "family delete")
+
+
+async def delete_event_tool(arguments) -> List[TextContent]:
+    """Delete an event by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_EVENT,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted event with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "event delete")
+
+
+async def delete_note_tool(arguments) -> List[TextContent]:
+    """Delete a note by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_NOTE,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted note with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "note delete")
+
+
+async def delete_citation_tool(arguments) -> List[TextContent]:
+    """Delete a citation by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_CITATION,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted citation with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "citation delete")
+
+
+async def delete_source_tool(arguments) -> List[TextContent]:
+    """Delete a source by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_SOURCE,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted source with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "source delete")
+
+
+async def delete_place_tool(arguments) -> List[TextContent]:
+    """Delete a place by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_PLACE,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted place with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "place delete")
+
+
+async def delete_repository_tool(arguments) -> List[TextContent]:
+    """Delete a repository by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_REPOSITORY,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted repository with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "repository delete")
+
+
+async def delete_media_tool(arguments) -> List[TextContent]:
+    """Delete a media item by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_MEDIA_ITEM,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted media with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "media delete")
+
+
+# ============================================================================
+# Tag Tools (CRUD)
+# ============================================================================
+
+
+async def find_tags_tool(arguments) -> List[TextContent]:
+    """Find/list all tags in the database."""
+    from ..models.parameters.tag_params import TagSearchParams
+
+    try:
+        params = _validate_params(arguments, TagSearchParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            tags = await client.make_api_call(
+                api_call=ApiCalls.GET_TAGS,
+                params=params,
+                tree_id=tree_id,
+            )
+
+            if not tags:
+                return [TextContent(type="text", text="No tags found.")]
+
+            result = f"Found {len(tags)} tags:\n\n"
+            for tag in tags:
+                name = tag.get("name", "Unnamed")
+                handle = tag.get("handle", "N/A")
+                color = tag.get("color", "")
+                priority = tag.get("priority", "")
+
+                result += f"- **{name}** [`{handle}`]"
+                if color:
+                    result += f" - Color: {color}"
+                if priority:
+                    result += f" - Priority: {priority}"
+                result += "\n"
+
+            return [TextContent(type="text", text=result)]
+
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "tags search")
+
+
+async def create_tag_tool(arguments) -> List[TextContent]:
+    """Create or update a tag."""
+    from ..models.parameters.tag_params import TagSaveParams
+
+    try:
+        params = _validate_params(arguments, TagSaveParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            if params.handle:
+                # Update existing tag
+                result = await client.make_api_call(
+                    api_call=ApiCalls.PUT_TAG,
+                    params=params,
+                    tree_id=tree_id,
+                    handle=params.handle,
+                )
+                operation = "updated"
+            else:
+                # Create new tag
+                result = await client.make_api_call(
+                    api_call=ApiCalls.POST_TAGS,
+                    params=params,
+                    tree_id=tree_id,
+                )
+                operation = "created"
+
+            # Extract tag data
+            if isinstance(result, list) and result:
+                tag_data = result[0].get("new", result[0])
+            else:
+                tag_data = result
+
+            name = tag_data.get("name", params.name)
+            handle = tag_data.get("handle", "N/A")
+
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully {operation} tag: **{name}** [`{handle}`]",
+                )
+            ]
+
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "tag save")
+
+
+async def delete_tag_tool(arguments) -> List[TextContent]:
+    """Delete a tag by handle."""
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            await client.make_api_call(
+                api_call=ApiCalls.DELETE_TAG,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Successfully deleted tag with handle: {params.handle}",
+                )
+            ]
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "tag delete")
+
+
+# ============================================================================
+# Media File Tools
+# ============================================================================
+
+
+async def get_media_file_tool(arguments) -> List[TextContent]:
+    """
+    Get information about a media file (metadata and download URL).
+
+    Note: This returns file metadata. The actual file can be accessed
+    via the Gramps Web UI or API directly.
+    """
+    from ..models.parameters.delete_params import DeleteParams
+
+    try:
+        params = _validate_params(arguments, DeleteParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        client = GrampsWebAPIClient()
+        try:
+            # First get media metadata
+            media_info = await client.make_api_call(
+                api_call=ApiCalls.GET_MEDIA_ITEM,
+                params=None,
+                tree_id=tree_id,
+                handle=params.handle,
+            )
+
+            if not media_info:
+                return [
+                    TextContent(type="text", text=f"Media not found: {params.handle}")
+                ]
+
+            # Format response
+            gramps_id = media_info.get("gramps_id", "N/A")
+            desc = media_info.get("desc", "No description")
+            mime = media_info.get("mime", "Unknown")
+            path = media_info.get("path", "")
+            checksum = media_info.get("checksum", "")
+
+            result = f"## Media File: {gramps_id}\n\n"
+            result += f"**Description:** {desc}\n"
+            result += f"**MIME Type:** {mime}\n"
+            result += f"**Path:** {path}\n"
+            result += f"**Handle:** `{params.handle}`\n"
+            if checksum:
+                result += f"**Checksum:** {checksum}\n"
+
+            # Provide download URL hint
+            api_url = settings.gramps_api_url
+            result += f"\n**File URL:** `{api_url}/api/trees/{tree_id}/media/{params.handle}/file`\n"
+
+            return [TextContent(type="text", text=result)]
+
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "media file info")
+
+
+async def upload_media_file_tool(arguments) -> List[TextContent]:
+    """
+    Upload a new media file from the local filesystem.
+
+    Creates a new media object in Gramps with the uploaded file.
+    Supports common image formats (jpg, png, gif, etc.), PDFs, and other media.
+    """
+    from ..models.parameters.media_params import MediaFileUploadParams
+
+    try:
+        params = _validate_params(arguments, MediaFileUploadParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Validate file exists
+        if not os.path.isfile(params.file_path):
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Error: File not found: {params.file_path}",
+                )
+            ]
+
+        # Read file content
+        with open(params.file_path, "rb") as f:
+            file_content = f.read()
+
+        # Determine MIME type
+        mime_type, _ = mimetypes.guess_type(params.file_path)
+        if not mime_type:
+            # Default to binary if unknown
+            mime_type = "application/octet-stream"
+
+        # Get file size for reporting
+        file_size = len(file_content)
+        file_name = os.path.basename(params.file_path)
+
+        client = GrampsWebAPIClient()
+        try:
+            result = await client.upload_media_file(
+                file_content=file_content,
+                mime_type=mime_type,
+                tree_id=tree_id,
+            )
+
+            # Extract created media info
+            if isinstance(result, list) and result:
+                media_data = result[0].get("new", result[0])
+            else:
+                media_data = result
+
+            handle = media_data.get("handle", "N/A")
+            gramps_id = media_data.get("gramps_id", "N/A")
+            checksum = media_data.get("checksum", "")
+
+            response = f"## Media File Uploaded Successfully\n\n"
+            response += f"**File:** {file_name}\n"
+            response += f"**Size:** {file_size:,} bytes\n"
+            response += f"**MIME Type:** {mime_type}\n"
+            response += f"**Gramps ID:** {gramps_id}\n"
+            response += f"**Handle:** `{handle}`\n"
+            if checksum:
+                response += f"**Checksum:** {checksum}\n"
+
+            if params.description:
+                response += f"\nNote: To add a description, use `create_media` with handle `{handle}`"
+
+            return [TextContent(type="text", text=response)]
+
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "media file upload")
+
+
+async def update_media_file_tool(arguments) -> List[TextContent]:
+    """
+    Update an existing media object's file from the local filesystem.
+
+    Replaces the file content of an existing media object.
+    The media object must already exist (use upload_media_file_tool to create new).
+    """
+    from ..models.parameters.media_params import MediaFileUpdateParams
+
+    try:
+        params = _validate_params(arguments, MediaFileUpdateParams)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        # Validate file exists
+        if not os.path.isfile(params.file_path):
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Error: File not found: {params.file_path}",
+                )
+            ]
+
+        # Read file content
+        with open(params.file_path, "rb") as f:
+            file_content = f.read()
+
+        # Determine MIME type
+        mime_type, _ = mimetypes.guess_type(params.file_path)
+        if not mime_type:
+            mime_type = "application/octet-stream"
+
+        file_size = len(file_content)
+        file_name = os.path.basename(params.file_path)
+
+        client = GrampsWebAPIClient()
+        try:
+            result = await client.update_media_file(
+                handle=params.handle,
+                file_content=file_content,
+                mime_type=mime_type,
+                tree_id=tree_id,
+            )
+
+            # Extract updated media info
+            if isinstance(result, list) and result:
+                media_data = result[0].get("new", result[0])
+            else:
+                media_data = result
+
+            gramps_id = media_data.get("gramps_id", "N/A")
+            checksum = media_data.get("checksum", "")
+
+            response = f"## Media File Updated Successfully\n\n"
+            response += f"**File:** {file_name}\n"
+            response += f"**Size:** {file_size:,} bytes\n"
+            response += f"**MIME Type:** {mime_type}\n"
+            response += f"**Gramps ID:** {gramps_id}\n"
+            response += f"**Handle:** `{params.handle}`\n"
+            if checksum:
+                response += f"**New Checksum:** {checksum}\n"
+
+            return [TextContent(type="text", text=response)]
+
+        finally:
+            await client.close()
+    except Exception as e:
+        return _format_error_response(e, "media file update")

--- a/src/gramps_mcp/tools/search_basic.py
+++ b/src/gramps_mcp/tools/search_basic.py
@@ -52,6 +52,15 @@ from ..models.parameters.source_params import SourceSearchParams
 logger = logging.getLogger(__name__)
 
 
+def _validate_params(arguments, param_class):
+    """Validate parameters - skip if already a validated Pydantic model."""
+    from pydantic import BaseModel
+
+    if isinstance(arguments, BaseModel):
+        return arguments
+    return param_class(**arguments)
+
+
 def with_client(func: Callable) -> Callable:
     """
     Decorator that provides a GrampsWebAPIClient instance and handles cleanup.
@@ -366,11 +375,19 @@ async def find_note_tool(client, arguments: Dict) -> List[TextContent]:
     )
 
 
-async def find_type_tool(arguments: Dict) -> List[TextContent]:
+async def find_type_tool(arguments) -> List[TextContent]:
     """Universal type-based search tool."""
-    entity_type = arguments.get("type")
-    gql = arguments.get("gql")
-    max_results = arguments.get("max_results", 20)
+    from pydantic import BaseModel
+
+    # Handle both dict and BaseModel inputs
+    if isinstance(arguments, BaseModel):
+        entity_type = arguments.type
+        gql = arguments.gql
+        max_results = getattr(arguments, "max_results", 20)
+    else:
+        entity_type = arguments.get("type")
+        gql = arguments.get("gql")
+        max_results = arguments.get("max_results", 20)
 
     # Get the string value from the enum if needed
     entity_type_str = (
@@ -391,13 +408,33 @@ async def find_type_tool(arguments: Dict) -> List[TextContent]:
 
 
 @with_client
-async def find_anything_tool(client, arguments: Dict) -> List[TextContent]:
+async def find_anything_tool(client, arguments) -> List[TextContent]:
     """
     Full-text search across all entity types.
     """
     try:
-        # Validate parameters
-        params = SearchParams(**arguments)
+        from pydantic import BaseModel
+        from ..models.parameters.simple_params import SimpleSearchParams
+
+        # Handle SimpleSearchParams (from FastMCP) or dict (from stdio)
+        if isinstance(arguments, SimpleSearchParams):
+            # Convert SimpleSearchParams to SearchParams
+            params = SearchParams(
+                query=arguments.query,
+                pagesize=arguments.max_results
+            )
+        elif isinstance(arguments, BaseModel):
+            # Other BaseModel - try to extract query
+            params = SearchParams(
+                query=getattr(arguments, "query", ""),
+                pagesize=getattr(arguments, "max_results", 20)
+            )
+        else:
+            # Dict from stdio transport
+            params = SearchParams(
+                query=arguments.get("query", ""),
+                pagesize=arguments.get("max_results", 20)
+            )
 
         # Get tree_id from settings
         settings = get_settings()

--- a/src/gramps_mcp/tools/search_basic.py
+++ b/src/gramps_mcp/tools/search_basic.py
@@ -414,27 +414,23 @@ async def find_anything_tool(client, arguments) -> List[TextContent]:
     """
     try:
         from pydantic import BaseModel
-        from ..models.parameters.simple_params import SimpleSearchParams
 
-        # Handle SimpleSearchParams (from FastMCP) or dict (from stdio)
-        if isinstance(arguments, SimpleSearchParams):
-            # Convert SimpleSearchParams to SearchParams
-            params = SearchParams(
-                query=arguments.query,
-                pagesize=arguments.max_results
-            )
-        elif isinstance(arguments, BaseModel):
-            # Other BaseModel - try to extract query
-            params = SearchParams(
-                query=getattr(arguments, "query", ""),
-                pagesize=getattr(arguments, "max_results", 20)
-            )
+        # Normalize arguments to a plain dict regardless of transport type.
+        # Reason: The MCP SDK may pass a Pydantic model or a raw dict depending
+        # on the transport (FastMCP vs stdio). Using model_dump() on any BaseModel
+        # avoids fragile isinstance chains that break when the model is reconstructed
+        # under a different import path or SDK version.
+        if isinstance(arguments, BaseModel):
+            data = arguments.model_dump()
+        elif isinstance(arguments, dict):
+            data = arguments
         else:
-            # Dict from stdio transport
-            params = SearchParams(
-                query=arguments.get("query", ""),
-                pagesize=arguments.get("max_results", 20)
-            )
+            data = {}
+
+        params = SearchParams(
+            query=data.get("query", ""),
+            pagesize=data.get("max_results", 20)
+        )
 
         # Get tree_id from settings
         settings = get_settings()

--- a/src/gramps_mcp/tools/search_details.py
+++ b/src/gramps_mcp/tools/search_details.py
@@ -35,6 +35,15 @@ from .search_basic import with_client
 logger = logging.getLogger(__name__)
 
 
+def _get_arg(arguments, key, default=None):
+    """Get argument value from either dict or BaseModel."""
+    from pydantic import BaseModel
+
+    if isinstance(arguments, BaseModel):
+        return getattr(arguments, key, default)
+    return arguments.get(key, default)
+
+
 def _format_error_response(error: Exception, operation: str) -> List[TextContent]:
     """Format error into user-friendly MCP response."""
     if isinstance(error, GrampsAPIError):
@@ -47,13 +56,13 @@ def _format_error_response(error: Exception, operation: str) -> List[TextContent
 
 
 @with_client
-async def get_person_tool(client, arguments: Dict) -> List[TextContent]:
+async def get_person_tool(client, arguments) -> List[TextContent]:
     """
     Get comprehensive person information using direct API calls.
     """
     try:
-        # Extract handle from arguments
-        handle = arguments.get("person_handle")
+        # Extract handle from arguments (handles both dict and BaseModel)
+        handle = _get_arg(arguments, "person_handle")
         if not handle:
             raise ValueError("person_handle is required")
 
@@ -71,13 +80,13 @@ async def get_person_tool(client, arguments: Dict) -> List[TextContent]:
 
 
 @with_client
-async def get_family_tool(client, arguments: Dict) -> List[TextContent]:
+async def get_family_tool(client, arguments) -> List[TextContent]:
     """
     Get detailed family information using direct API calls.
     """
     try:
-        # Extract handle from arguments
-        handle = arguments.get("family_handle")
+        # Extract handle from arguments (handles both dict and BaseModel)
+        handle = _get_arg(arguments, "family_handle")
         if not handle:
             raise ValueError("family_handle is required")
 
@@ -94,11 +103,11 @@ async def get_family_tool(client, arguments: Dict) -> List[TextContent]:
         return _format_error_response(e, "family details retrieval")
 
 
-async def get_type_tool(arguments: Dict) -> List[TextContent]:
+async def get_type_tool(arguments) -> List[TextContent]:
     """Universal get tool for person and family details."""
-    entity_type = arguments.get("type")
-    handle = arguments.get("handle")
-    gramps_id = arguments.get("gramps_id")
+    entity_type = _get_arg(arguments, "type")
+    handle = _get_arg(arguments, "handle")
+    gramps_id = _get_arg(arguments, "gramps_id")
 
     # If gramps_id provided but no handle, find the handle first
     if gramps_id and not handle:

--- a/tests/test_search_basic.py
+++ b/tests/test_search_basic.py
@@ -303,3 +303,32 @@ class TestFindAnythingTool:
             result_count = result[0].text.count("• **")
             assert result_count <= 3, f"Expected max 3 results, got {result_count}"
 
+    @pytest.mark.asyncio
+    async def test_find_anything_with_pydantic_model(self):
+        """Test find_anything_tool accepts a Pydantic BaseModel as arguments.
+
+        Regression test: Previously, isinstance checks against SimpleSearchParams
+        could fail when the MCP SDK reconstructed the model under a different
+        import path, causing the tool to silently use an empty query. This test
+        ensures that any BaseModel input is handled correctly via model_dump().
+        """
+        from pydantic import BaseModel
+
+        class ArbitraryMCPModel(BaseModel):
+            query: str
+            max_results: int = 20
+
+        arguments = ArbitraryMCPModel(query="pietrala", max_results=3)
+        result = await find_anything_tool(arguments)
+
+        assert len(result) == 1
+        assert isinstance(result[0], TextContent)
+        assert "error" not in result[0].text.lower(), (
+            f"Error found in response: {result[0].text}"
+        )
+        # The query must have been forwarded correctly - an empty query would
+        # either error or return unrelated results without "pietrala" in the header
+        assert "pietrala" in result[0].text, (
+            f"Expected 'pietrala' in response, got: {result[0].text}"
+        )
+


### PR DESCRIPTION
## Summary

This PR contributes two sets of changes developed while using gramps-mcp in production:

### Bug Fix: Pydantic transport compatibility in `find_anything_tool`

The `find_anything_tool` was silently sending empty queries when invoked via certain MCP transports (e.g. HTTP/SSE). Root cause: the MCP SDK reconstructs Pydantic models under a different import path depending on transport, causing `isinstance(args, SimpleSearchParams)` to fail even for valid model instances. 

**Fix:** Replace the fragile isinstance chain with a single `model_dump()` call that works regardless of how the model was constructed. Includes a regression test that simulates the SDK behavior by passing an arbitrary `BaseModel` subclass.

### Feature: Expand from 16 to 39 tools

New tools developed against the Gramps Web API:

**Delete Tools (10):** `delete_person`, `delete_family`, `delete_event`, `delete_note`, `delete_citation`, `delete_source`, `delete_place`, `delete_repository`, `delete_media`, `delete_tag`

**Tag Tools (3):** `find_tags`, `create_tag`, `delete_tag`

**Media File Tools (3):** `get_media_file`, `upload_media_file`, `update_media_file`

**Analysis Tools (expanded to 12):** `get_relations`, `get_relations_all`, `get_living`, `get_facts`, `get_people_timeline`, `get_families_timeline`, `get_event_span`, `get_types` (plus existing descendants/ancestors/tree_stats/recent_changes)

**Other improvements:**
- Alternate names display in person handlers (married names, maiden names)
- `alternate_names` field support in person creation/update
- `child_handles` serialization fix for family creation (converts to full `child_ref_list` format the API expects)
- `exclude_unset=True` in GET requests to prevent sending unwanted default parameters
- Trailing slash fixes on several API endpoint URLs
- `update_media_file()` client method (HTTP PUT to `/media/{handle}/file`)

## Test plan

- [x] All existing tests pass
- [ ] New regression test `test_find_anything_with_pydantic_model` covers the transport bug
- [ ] Delete tools verified against live Gramps Web API instance
- [ ] Media upload/update tested with Docker volume mount setup (documented in README)