### PR TITLE
fix(tools): raise GrampsAPIError so MCP framework reports isError=true

### DIFF
--- a/src/gramps_mcp/tools/analysis.py
+++ b/src/gramps_mcp/tools/analysis.py
@@ -38,15 +38,20 @@ from .search_basic import with_client
 logger = logging.getLogger(__name__)
 
 
-def _format_error_response(error: Exception, operation: str) -> List[TextContent]:
-    """Format error into user-friendly MCP response."""
+def _format_error_response(error: Exception, operation: str) -> None:
+    """Raise a GrampsAPIError so the MCP framework reports isError=true.
+
+    Previously this returned a TextContent with "Error: ..." which the MCP
+    framework treated as a successful response (isError=false). Raising lets the
+    framework surface the error as a real protocol-level error.
+    """
     if isinstance(error, GrampsAPIError):
         error_msg = str(error)
     else:
         error_msg = f"Unexpected error during {operation}: {str(error)}"
 
     logger.error(f"Tool error in {operation}: {error_msg}")
-    return [TextContent(type="text", text=f"Error: {error_msg}")]
+    raise GrampsAPIError(error_msg)
 
 
 async def _format_recent_changes(
@@ -269,7 +274,7 @@ async def get_descendants_tool(client, arguments: Dict) -> List[TextContent]:
         return [TextContent(type="text", text=markdown_content)]
 
     except Exception as e:
-        return _format_error_response(e, "descendants search")
+        _format_error_response(e, "descendants search")
 
 
 @with_client
@@ -362,7 +367,7 @@ async def get_ancestors_tool(client, arguments: Dict) -> List[TextContent]:
         return [TextContent(type="text", text=markdown_content)]
 
     except Exception as e:
-        return _format_error_response(e, "ancestors search")
+        _format_error_response(e, "ancestors search")
 
 
 @with_client
@@ -393,7 +398,7 @@ async def get_recent_changes_tool(client, arguments: Dict) -> List[TextContent]:
         return [TextContent(type="text", text=formatted_changes)]
 
     except Exception as e:
-        return _format_error_response(e, "recent changes retrieval")
+        _format_error_response(e, "recent changes retrieval")
 
 
 def _format_tree_info(tree_info: Dict) -> str:
@@ -448,4 +453,4 @@ async def get_tree_info_tool(client, _arguments: Dict) -> List[TextContent]:
         return [TextContent(type="text", text=formatted_info)]
 
     except Exception as e:
-        return _format_error_response(e, "tree information retrieval")
+        _format_error_response(e, "tree information retrieval")

--- a/src/gramps_mcp/tools/data_management.py
+++ b/src/gramps_mcp/tools/data_management.py
@@ -51,15 +51,20 @@ from ..models.parameters.source_params import SourceSaveParams
 logger = logging.getLogger(__name__)
 
 
-def _format_error_response(error: Exception, operation: str) -> List[TextContent]:
-    """Format error into user-friendly MCP response."""
+def _format_error_response(error: Exception, operation: str) -> None:
+    """Raise a GrampsAPIError so the MCP framework reports isError=true.
+
+    Previously this returned a TextContent with "Error: ..." which the MCP
+    framework treated as a successful response (isError=false). Raising lets the
+    framework surface the error as a real protocol-level error.
+    """
     if isinstance(error, GrampsAPIError):
         error_msg = str(error)
     else:
         error_msg = f"Unexpected error during {operation}: {str(error)}"
 
     logger.error(f"Tool error in {operation}: {error_msg}")
-    return [TextContent(type="text", text=f"Error: {error_msg}")]
+    raise GrampsAPIError(error_msg)
 
 
 def _extract_entity_data(result, entity_type: str = None):
@@ -127,7 +132,7 @@ async def _handle_crud_operation(
             await client.close()
 
     except Exception as e:
-        return _format_error_response(e, f"{entity_type} save")
+        _format_error_response(e, f"{entity_type} save")
 
 
 async def _format_save_response(
@@ -238,7 +243,7 @@ async def create_family_tool(arguments: Dict) -> List[TextContent]:
             await client.close()
 
     except Exception as e:
-        return _format_error_response(e, "family save")
+        _format_error_response(e, "family save")
 
 
 async def create_event_tool(arguments: Dict) -> List[TextContent]:
@@ -377,7 +382,7 @@ async def create_media_tool(arguments: Dict) -> List[TextContent]:
             await client.close()
 
     except Exception as e:
-        return _format_error_response(e, "media save")
+        _format_error_response(e, "media save")
 
 
 async def create_repository_tool(arguments: Dict) -> List[TextContent]:
@@ -441,4 +446,4 @@ async def create_repository_tool(arguments: Dict) -> List[TextContent]:
             await client.close()
 
     except Exception as e:
-        return _format_error_response(e, "repository save")
+        _format_error_response(e, "repository save")

--- a/src/gramps_mcp/tools/search_basic.py
+++ b/src/gramps_mcp/tools/search_basic.py
@@ -212,18 +212,23 @@ async def _search_entities(
         return [TextContent(type="text", text=formatted_results)]
 
     except Exception as e:
-        return _format_error_response(e, f"{entity_type} search")
+        _format_error_response(e, f"{entity_type} search")
 
 
-def _format_error_response(error: Exception, operation: str) -> List[TextContent]:
-    """Format error into user-friendly MCP response."""
+def _format_error_response(error: Exception, operation: str) -> None:
+    """Raise a GrampsAPIError so the MCP framework reports isError=true.
+
+    Previously this returned a TextContent with "Error: ..." which the MCP
+    framework treated as a successful response (isError=false). Raising lets the
+    framework surface the error as a real protocol-level error.
+    """
     if isinstance(error, GrampsAPIError):
         error_msg = str(error)
     else:
         error_msg = f"Unexpected error during {operation}: {str(error)}"
 
     logger.error(f"Tool error in {operation}: {error_msg}")
-    return [TextContent(type="text", text=f"Error: {error_msg}")]
+    raise GrampsAPIError(error_msg)
 
 
 # ============================================================================
@@ -449,4 +454,4 @@ async def find_anything_tool(client, arguments: Dict) -> List[TextContent]:
         return [TextContent(type="text", text=formatted_results)]
 
     except Exception as e:
-        return _format_error_response(e, "full-text search")
+        _format_error_response(e, "full-text search")

--- a/src/gramps_mcp/tools/search_details.py
+++ b/src/gramps_mcp/tools/search_details.py
@@ -35,15 +35,20 @@ from .search_basic import with_client
 logger = logging.getLogger(__name__)
 
 
-def _format_error_response(error: Exception, operation: str) -> List[TextContent]:
-    """Format error into user-friendly MCP response."""
+def _format_error_response(error: Exception, operation: str) -> None:
+    """Raise a GrampsAPIError so the MCP framework reports isError=true.
+
+    Previously this returned a TextContent with "Error: ..." which the MCP
+    framework treated as a successful response (isError=false). Raising lets the
+    framework surface the error as a real protocol-level error.
+    """
     if isinstance(error, GrampsAPIError):
         error_msg = str(error)
     else:
         error_msg = f"Unexpected error during {operation}: {str(error)}"
 
     logger.error(f"Tool error in {operation}: {error_msg}")
-    return [TextContent(type="text", text=f"Error: {error_msg}")]
+    raise GrampsAPIError(error_msg)
 
 
 @with_client
@@ -67,7 +72,7 @@ async def get_person_tool(client, arguments: Dict) -> List[TextContent]:
         return [TextContent(type="text", text=formatted_person)]
 
     except Exception as e:
-        return _format_error_response(e, "person details retrieval")
+        _format_error_response(e, "person details retrieval")
 
 
 @with_client
@@ -91,7 +96,7 @@ async def get_family_tool(client, arguments: Dict) -> List[TextContent]:
         return [TextContent(type="text", text=formatted_family)]
 
     except Exception as e:
-        return _format_error_response(e, "family details retrieval")
+        _format_error_response(e, "family details retrieval")
 
 
 async def get_type_tool(arguments: Dict) -> List[TextContent]:


### PR DESCRIPTION
The per-tool `_format_error_response` helper returned `TextContent(type='text', text='Error: ...')` from inside except blocks. The MCP framework treats any non-exception return as a successful tool call, so callers saw `isError=false` even when the tool had failed. AI agents consuming the response would treat the error string as a valid result.

Changed all four `_format_error_response` helpers (analysis, data_management, search_basic, search_details) to raise `GrampsAPIError` instead of returning `TextContent`. The exception propagates through the `@with_client` wrapper and the MCP framework surfaces it as a real protocol-level error.