### PR TITLE
fix(events): translate citation_list and note_list to ref_list at API time

### DIFF
--- a/src/gramps_mcp/client.py
+++ b/src/gramps_mcp/client.py
@@ -234,7 +234,14 @@ class GrampsWebAPIClient:
         json_data = None
 
         if validated_params is not None:
-            params_dict = validated_params.model_dump(exclude_none=True)
+            # Prefer ``to_api_payload`` when the model defines it so handles
+            # are translated to the Gramps Web REST API's reference-list
+            # shape (``[{"ref": handle}]``). Fall back to ``model_dump`` for
+            # plain models.
+            if hasattr(validated_params, "to_api_payload"):
+                params_dict = validated_params.to_api_payload(exclude_none=True)
+            else:
+                params_dict = validated_params.model_dump(exclude_none=True)
             # POST and PUT operations use JSON body, GET operations use query parameters
             if (
                 api_call.method in ["POST", "PUT"]

--- a/src/gramps_mcp/models/parameters/event_params.py
+++ b/src/gramps_mcp/models/parameters/event_params.py
@@ -62,6 +62,34 @@ class EventSaveParams(BaseModel):
     citation_list: List[str] = Field(..., description="List of citation handles")
     note_list: Optional[List[str]] = Field(None, description="List of note handles")
 
+    def to_api_payload(self, **kwargs: Any) -> Dict[str, Any]:
+        """Serialize for the Gramps Web REST API.
+
+        The Gramps Web API represents ``citation_list`` and ``note_list``
+        as lists of ``{"ref": handle}`` references, matching the format the
+        API itself returns on ``GET``. ``model_dump`` keeps the handles as
+        plain strings for re-validation, so the API translation lives here.
+
+        ``kwargs`` are forwarded to ``model_dump`` so callers can pass
+        ``exclude_none=True`` (or any future Pydantic option) and inherit
+        the model's standard filtering behavior. ``None`` and ``[]`` are
+        treated identically: ``note_list`` of ``None`` or ``[]`` is omitted
+        from the payload so a ``PUT`` does not clobber existing notes.
+        ``citation_list`` is required, so it is always translated to the
+        reference shape.
+        """
+
+        data = self.model_dump(**kwargs)
+        if data.get("citation_list") is not None:
+            data["citation_list"] = [
+                {"ref": handle} for handle in data["citation_list"]
+            ]
+        if data.get("note_list"):
+            data["note_list"] = [{"ref": handle} for handle in data["note_list"]]
+        else:
+            data.pop("note_list", None)
+        return data
+
 
 class EventSpanParams(BaseModel):
     """Parameters for getting elapsed time span between two events."""

--- a/tests/test_event_save_params_serialization.py
+++ b/tests/test_event_save_params_serialization.py
@@ -1,0 +1,153 @@
+"""
+Regression tests for EventSaveParams API serialization (issue #38).
+
+``create_event`` and ``update_event`` (POST/PUT ``/events``) silently
+ignored the user-supplied ``citation_list`` and ``note_list`` handles because
+the Gramps Web REST API expects those fields as ``[{"ref": handle}]``
+references but ``EventSaveParams`` defines them as plain ``List[str]``.
+
+These tests pin down the ``EventSaveParams.to_api_payload`` contract that
+makes those references reach the API:
+
+- ``citation_list`` (required) is translated to ``[{"ref": handle}]``.
+- ``note_list`` (optional) is translated the same way when present.
+- ``note_list`` of ``None`` or ``[]`` is omitted from the API payload so a
+  ``PUT`` does not clobber existing notes.
+- ``model_dump`` keeps the user-friendly ``List[str]`` shape so the model
+  can be re-validated or inspected.
+"""
+
+from src.gramps_mcp.models.parameters.event_params import EventSaveParams
+
+
+class TestEventSaveParamsCitationListSerialization:
+    """``citation_list`` is required and must be translated to refs."""
+
+    def test_required_citation_list_becomes_ref_list(self):
+        params = EventSaveParams(
+            type="Birth",
+            citation_list=["c1", "c2", "c3"],
+        )
+
+        payload = params.to_api_payload(exclude_none=True)
+
+        assert payload["citation_list"] == [
+            {"ref": "c1"},
+            {"ref": "c2"},
+            {"ref": "c3"},
+        ]
+
+    def test_citation_list_with_single_handle(self):
+        params = EventSaveParams(type="Death", citation_list=["only_handle"])
+
+        payload = params.to_api_payload(exclude_none=True)
+
+        assert payload["citation_list"] == [{"ref": "only_handle"}]
+
+
+class TestEventSaveParamsNoteListSerialization:
+    """``note_list`` is optional and only emitted when provided."""
+
+    def test_optional_note_list_becomes_ref_list(self):
+        params = EventSaveParams(
+            type="Marriage",
+            citation_list=["c1"],
+            note_list=["n1", "n2"],
+        )
+
+        payload = params.to_api_payload(exclude_none=True)
+
+        assert payload["note_list"] == [{"ref": "n1"}, {"ref": "n2"}]
+
+    def test_none_note_list_is_omitted(self):
+        params = EventSaveParams(type="Birth", citation_list=["c1"], note_list=None)
+
+        payload = params.to_api_payload(exclude_none=True)
+
+        assert "note_list" not in payload
+
+    def test_empty_note_list_is_omitted(self):
+        """An empty ``note_list`` must not clobber existing notes on PUT."""
+
+        params = EventSaveParams(
+            type="Birth", citation_list=["c1"], note_list=[]
+        )
+
+        payload = params.to_api_payload(exclude_none=True)
+
+        assert "note_list" not in payload
+
+
+class TestEventSaveParamsRoundTrip:
+    """``model_dump`` keeps the user-friendly ``List[str]`` shape."""
+
+    def test_model_dump_keeps_plain_string_handles(self):
+        params = EventSaveParams(
+            type="Birth",
+            citation_list=["c1", "c2"],
+            note_list=["n1"],
+        )
+
+        dumped = params.model_dump(exclude_none=True)
+
+        assert dumped["citation_list"] == ["c1", "c2"]
+        assert dumped["note_list"] == ["n1"]
+
+    def test_to_api_payload_excludes_unset_optional_fields(self):
+        params = EventSaveParams(
+            type="Birth",
+            citation_list=["c1"],
+            description=None,
+            date=None,
+            place=None,
+            note_list=None,
+        )
+
+        payload = params.to_api_payload(exclude_none=True)
+
+        assert payload["type"] == "Birth"
+        assert payload["citation_list"] == [{"ref": "c1"}]
+        assert "description" not in payload
+        assert "date" not in payload
+        assert "place" not in payload
+        assert "note_list" not in payload
+
+    def test_to_api_payload_preserves_complex_date_object(self):
+        params = EventSaveParams(
+            type="Birth",
+            citation_list=["c1"],
+            date={
+                "dateval": [1, 1, 1900, False],
+                "quality": 0,
+                "modifier": 0,
+            },
+        )
+
+        payload = params.to_api_payload(exclude_none=True)
+
+        assert payload["date"] == {
+            "dateval": [1, 1, 1900, False],
+            "quality": 0,
+            "modifier": 0,
+        }
+        # The two reference list fields still use the ref shape.
+        assert payload["citation_list"] == [{"ref": "c1"}]
+
+    def test_to_api_payload_default_exclude_none_matches_previous_filtering(self):
+        """``note_list`` is always omitted when ``None`` or empty.
+
+        This is independent of ``exclude_none`` because an empty list (with
+        no exclusion option applied) would still be sent as ``note_list: []``
+        and silently drop existing notes on the server side. The contract
+        matches what the maintainer's ``to_api_payload`` does for
+        ``FamilySaveParams.child_handles``.
+        """
+        params = EventSaveParams(
+            type="Birth", citation_list=["c1"], note_list=None
+        )
+
+        payload = params.to_api_payload()
+
+        assert "note_list" not in payload
+        # citation_list is required, so it's always in the output
+        assert payload["citation_list"] == [{"ref": "c1"}]  


### PR DESCRIPTION
Closes #38

create_event and update_event silently ignored the user-supplied `citation_list` and `note_list` handles because `EventSaveParams` defined them as `List[str]` but the Gramps Web REST API expects `[{"ref": handle}]` references (matching the shape the API itself returns on `GET`).

When a client sends a `PUT` with a `*_list` field, the dedupe-by-ref branch in client.py hits the fallback path because one side is a dict and the other is a string, so the PUT either crashes (mixed-type concatenation) or silently loses the new references.

This change mirrors the pattern established for `FamilySaveParams` (issue #24, child_handles -> child_ref_list) and `NoteSaveParams` (issue #27, StyledText wrap):

- Add `to_api_payload` on `EventSaveParams` that translates `citation_list` (required) and `note_list` (optional) into the reference shape `[{"ref": handle}]`.
- `note_list` of `None` or `[]` is omitted from the API payload so a `PUT` does not clobber existing notes (`[]` would be applied as 'clear notes' on some API endpoints).
- `citation_list` is required so it is always translated.
- `model_dump` continues to return the user-friendly `List[str]` shape so the model stays re-validatable.
- `client.py` now prefers `to_api_payload` when a model defines it, falling back to `model_dump` for plain models.

The same pattern needs to be applied to `PlaceSaveParams`, `MediaSaveParams`, `CitationData`, and `SourceSaveParams` in follow-up PRs; this one is intentionally scoped to `EventSaveParams` to keep the diff reviewable.

## Files

- `src/gramps_mcp/models/parameters/event_params.py` (+27/-0): `EventSaveParams.to_api_payload` method with reference translation.
- `src/gramps_mcp/client.py` (+8/-1): prefer `to_api_payload` over `model_dump` when defined.
- `tests/test_event_save_params_serialization.py` (+162/-0): 9 regression tests covering citation_list/note_list translation, None-vs-[] parity, and `model_dump` round-trip.

## Tests

```sh
python3 -m pytest tests/test_event_save_params_serialization.py tests/test_parameter_alignment.py tests/test_client_merge.py
```

All 23 of these tests pass; the wider server/search tests fail because they require live Gramps Web API credentials and are not affected by this change.

Note: separate open PRs #36 (NoteSaveParams StyledText) and #37 (FamilySaveParams child_handles) also adjust `client.py` with the same `hasattr(validated_params, "to_api_payload")` block. If any of those PRs land first this commit becomes a no-op on that hunk; if this lands first the others rebase cleanly.