### PR TITLE
fix: four tool handlers that error or silently drop data (notes, family children, get_type)

### DIFF
--- a/src/gramps_mcp/handlers/family_detail_handler.py
+++ b/src/gramps_mcp/handlers/family_detail_handler.py
@@ -213,9 +213,16 @@ async def format_family_detail(client, tree_id: str, handle: str) -> str:
                     ApiCalls.GET_NOTE, tree_id=tree_id, handle=note_handle
                 )
                 note_type = note_data.get("type", "")
+                if isinstance(note_type, dict):
+                    note_type = note_type.get("string", "")
                 note_id = note_data.get("gramps_id", "")
-                note_text = note_data.get("text", "")[:50]  # First 50 chars
-                if len(note_data.get("text", "")) > 50:
+                # note "text" is a StyledText dict ({"string": ...}); slicing the
+                # dict raises "unhashable type: 'slice'". Extract the string.
+                raw_text = note_data.get("text", "")
+                if isinstance(raw_text, dict):
+                    raw_text = raw_text.get("string", "")
+                note_text = raw_text[:50]  # First 50 chars
+                if len(raw_text) > 50:
                     note_text += "..."
                 result += f"- {note_type}: {note_text} ({note_id})\n"
             except Exception:

--- a/src/gramps_mcp/handlers/person_detail_handler.py
+++ b/src/gramps_mcp/handlers/person_detail_handler.py
@@ -280,9 +280,18 @@ async def format_person_detail(client, tree_id: str, handle: str) -> str:
             ApiCalls.GET_NOTE, tree_id=tree_id, handle=note_handle
         )
         note_type = note_data.get("type", "")
+        if isinstance(note_type, dict):
+            note_type = note_type.get("string", "")
         note_id = note_data.get("gramps_id", "")
-        note_text = note_data.get("text", "")[:50]
-        if len(note_data.get("text", "")) > 50:
+        # A note's "text" comes back as a Gramps StyledText dict
+        # ({"_class": "StyledText", "string": ...}), not a plain string.
+        # Slicing the dict directly raises "unhashable type: 'slice'", which
+        # crashed get_type for any person/family that had an attached note.
+        raw_text = note_data.get("text", "")
+        if isinstance(raw_text, dict):
+            raw_text = raw_text.get("string", "")
+        note_text = raw_text[:50]
+        if len(raw_text) > 50:
             note_text += "..."
         result += f"- {note_type}: {note_text} ({note_id})\n"
 

--- a/src/gramps_mcp/models/parameters/family_params.py
+++ b/src/gramps_mcp/models/parameters/family_params.py
@@ -26,7 +26,7 @@ API calls supported in this category:
 - GET_FAMILY_TIMELINE: Get the timeline for all the people in a specific family
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -40,7 +40,16 @@ class FamilySaveParams(BaseModel):
     father_handle: Optional[str] = Field(None, description="Father's handle")
     mother_handle: Optional[str] = Field(None, description="Mother's handle")
     child_handles: Optional[List[str]] = Field(
-        None, description="List of child handles"
+        None, description="List of child person handles"
+    )
+    # Internal/API shape. Callers should use `child_handles`; model_dump() below
+    # converts those into this ChildRef list, which is what the Gramps API
+    # actually persists. Declared as a field (not only built inside model_dump)
+    # so the FastMCP validate -> model_dump -> re-validate round-trip preserves
+    # it instead of dropping it as an unknown key (which silently lost every
+    # child).
+    child_ref_list: Optional[List[dict]] = Field(
+        None, description="ChildRef objects (built from child_handles; advanced use)"
     )
     event_ref_list: Optional[List[dict]] = Field(
         None, description="List of event references"
@@ -52,6 +61,37 @@ class FamilySaveParams(BaseModel):
     media_list: Optional[List[dict]] = Field(
         None, description="List of media references"
     )
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        """Convert child_handles into the ChildRef list the Gramps API expects.
+
+        The API stores children as ``child_ref_list`` entries shaped like
+        ``{"_class": "ChildRef", "ref": <handle>, "frel": "Birth",
+        "mrel": "Birth"}`` — NOT as a bare ``child_handles`` list. Sending
+        ``child_handles`` makes the API silently ignore it: the family saves
+        but with no children. Here we translate handles into ChildRef objects
+        (deduped against any explicit ``child_ref_list``) and drop the
+        ``child_handles`` key. grampsweb maintains the reciprocal
+        ``parent_family_list`` on each child automatically.
+        """
+        data = super().model_dump(**kwargs)
+        handles = data.pop("child_handles", None)
+        if handles:
+            child_refs = data.get("child_ref_list") or []
+            seen = {r.get("ref") for r in child_refs if isinstance(r, dict)}
+            for handle in handles:
+                if handle not in seen:
+                    child_refs.append(
+                        {
+                            "_class": "ChildRef",
+                            "ref": handle,
+                            "frel": "Birth",
+                            "mrel": "Birth",
+                        }
+                    )
+                    seen.add(handle)
+            data["child_ref_list"] = child_refs
+        return data
 
 
 class FamilyTimelineParams(BaseModel):

--- a/src/gramps_mcp/models/parameters/note_params.py
+++ b/src/gramps_mcp/models/parameters/note_params.py
@@ -26,7 +26,7 @@ API calls supported in this category:
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .base_params import BaseGetMultipleParams, BaseGetSingleParams
 
@@ -66,6 +66,25 @@ class NoteSaveParams(BaseModel):
     )
     text: str = Field(..., description="Note text content")
     type: str = Field(..., description="The type of note")
+
+    @field_validator("text", mode="before")
+    @classmethod
+    def _normalize_text(cls, v: Any) -> Any:
+        """Accept either a plain string or a Gramps StyledText dict.
+
+        ``model_dump`` below converts the plain string into a StyledText dict
+        (``{"_class": "StyledText", "string": ...}``) for the API. The FastMCP
+        dispatch layer validates the tool arguments into this model and then
+        calls ``model_dump()`` before handing the dict to the tool handler,
+        which re-validates it against this same model. Without this normalizer
+        that round-trip (validate -> model_dump -> validate) feeds a dict back
+        into the ``str`` ``text`` field and raises a validation error, breaking
+        every create_note / update_note call. Extracting ``string`` here makes
+        the round-trip idempotent.
+        """
+        if isinstance(v, dict):
+            return v.get("string", "")
+        return v
 
     def model_dump(self, **kwargs: Any) -> dict[str, Any]:
         """Convert to API format with StyledText structure."""

--- a/src/gramps_mcp/tools/search_basic.py
+++ b/src/gramps_mcp/tools/search_basic.py
@@ -23,6 +23,7 @@ places, sources, citations, media, and full-text search across all entity types.
 
 import functools
 import logging
+import re
 from typing import Callable, Dict, List
 
 from mcp.types import TextContent
@@ -356,14 +357,148 @@ async def find_citation_tool(client, arguments: Dict) -> List[TextContent]:
     )
 
 
+# Fields on a note object that client-side note filtering understands.
+# "text" maps to the StyledText string payload.
+def _note_field_value(note: Dict, field: str):
+    """Return the comparable value of a note field for client-side filtering."""
+    if field in ("text", "text.string"):
+        text = note.get("text")
+        if isinstance(text, dict):
+            return text.get("string", "")
+        return text or ""
+    return note.get(field)
+
+
+def _parse_gql_predicates(gql):
+    """Parse a small, safe subset of GQL into (field, op, value) predicates.
+
+    Supported forms (joined by ``and``):
+        field = "value"    field == "value"    field != "value"
+        "substr" in field
+
+    Returns a list of predicates (empty list means "match everything"), or
+    ``None`` if any part of the query cannot be parsed (caller should then
+    tell the user the filter is unsupported rather than return wrong results).
+    """
+    if not gql or not gql.strip():
+        return []
+
+    predicates = []
+    for part in re.split(r"\s+and\s+", gql.strip(), flags=re.IGNORECASE):
+        part = part.strip()
+        eq = re.match(r'^(\w+(?:\.\w+)?)\s*(==|=|!=)\s*"([^"]*)"$', part)
+        if eq:
+            predicates.append((eq.group(1), eq.group(2), eq.group(3)))
+            continue
+        contains = re.match(
+            r'^"([^"]*)"\s+in\s+(\w+(?:\.\w+)?)$', part, flags=re.IGNORECASE
+        )
+        if contains:
+            predicates.append((contains.group(2), "contains", contains.group(1)))
+            continue
+        return None  # unparseable predicate
+    return predicates
+
+
+def _note_matches(note: Dict, predicates) -> bool:
+    """Evaluate parsed predicates against a single note object."""
+    for field, op, value in predicates:
+        actual = _note_field_value(note, field)
+        if op in ("=", "=="):
+            if str(actual) != value:
+                return False
+        elif op == "!=":
+            if str(actual) == value:
+                return False
+        elif op == "contains":
+            if value.lower() not in str(actual or "").lower():
+                return False
+    return True
+
+
+async def _fetch_all_notes(client, tree_id: str, cap: int = 5000) -> List[Dict]:
+    """Fetch all notes WITHOUT a gql filter.
+
+    This backend's /notes endpoint returns HTTP 500 for any ``gql`` query (a
+    server-side bug in its GQL engine; other entity types are unaffected).
+    Fetching without ``gql`` works, so we page through all notes and filter
+    client-side. Paging is capped to avoid unbounded fetches.
+    """
+    notes: List[Dict] = []
+    page = 1
+    page_size = 200
+    while len(notes) < cap:
+        response = await client.make_api_call(
+            api_call=ApiCalls.GET_NOTES,
+            params=NotesParams(page=page, pagesize=page_size),
+            tree_id=tree_id,
+        )
+        batch = response if isinstance(response, list) else response.get("data", [])
+        if not batch:
+            break
+        notes.extend(batch)
+        if len(batch) < page_size:
+            break
+        page += 1
+    return notes
+
+
 @with_client
 async def find_note_tool(client, arguments: Dict) -> List[TextContent]:
     """
     Search for notes and research notes.
+
+    Works around a grampsweb backend bug: any ``gql`` query against the /notes
+    endpoint returns HTTP 500. Instead of sending ``gql``, this fetches notes
+    unfiltered and applies a supported subset of GQL client-side. See
+    ``_parse_gql_predicates`` for the supported syntax.
     """
-    return await _search_entities(
-        client, arguments, NotesParams, ApiCalls.GET_NOTES, "notes", format_note
-    )
+    try:
+        gql = arguments.get("gql")
+        pagesize = arguments.get("pagesize")
+
+        predicates = _parse_gql_predicates(gql)
+        settings = get_settings()
+        tree_id = settings.gramps_tree_id
+
+        if predicates is None:
+            return [
+                TextContent(
+                    type="text",
+                    text=(
+                        f"Note search could not apply the filter {gql!r}. "
+                        "This backend cannot run GQL against notes, so note "
+                        "search supports a subset applied locally: "
+                        'field =/==/!= "value" and "substr" in field, '
+                        "combined with `and`."
+                    ),
+                )
+            ]
+
+        all_notes = await _fetch_all_notes(client, tree_id)
+        matched = [n for n in all_notes if _note_matches(n, predicates)]
+        total_count = len(matched)
+
+        if pagesize:
+            matched = matched[:pagesize]
+
+        if not matched:
+            formatted_results = "No notes found"
+        else:
+            if total_count > len(matched):
+                header = f"Found {total_count} notes (showing {len(matched)}):\n\n"
+            else:
+                header = f"Found {total_count} notes:\n\n"
+            formatted_results = header
+            for note in matched:
+                handle = note.get("handle", "")
+                if handle:
+                    formatted_results += await format_note(client, tree_id, handle)
+
+        return [TextContent(type="text", text=formatted_results)]
+
+    except Exception as e:
+        return _format_error_response(e, "notes search")
 
 
 async def find_type_tool(arguments: Dict) -> List[TextContent]:

--- a/src/gramps_mcp/tools/search_details.py
+++ b/src/gramps_mcp/tools/search_details.py
@@ -108,13 +108,26 @@ async def get_type_tool(arguments: Dict) -> List[TextContent]:
             {"type": entity_type, "gql": f'gramps_id="{gramps_id}"', "max_results": 1}
         )
 
-        # Extract handle from search result
+        # Extract handle from search result.
+        # The formatted identity line looks like:
+        #   "[Unknown] Berry (M) - I0089 - [1034b42418c65209fb87d0d52d4c]"
+        # A naive first-"[...]" match grabs bracketed name tokens such as
+        # "[Unknown]" instead of the handle, producing a bogus handle and a
+        # "Record not found" error. Gramps handles are long hex strings, so
+        # match those specifically; fall back to the last bracketed token on
+        # the first result block (the format always ends the identity line
+        # with the handle).
         search_text = search_result[0].text
         import re
 
-        handle_match = re.search(r"\[([^\]]+)\]", search_text)
-        if handle_match:
-            handle = handle_match.group(1)
+        handle_matches = re.findall(r"\[([0-9a-fA-F]{16,})\]", search_text)
+        if handle_matches:
+            handle = handle_matches[0]
+        else:
+            first_block = search_text.split("\n\n")[0]
+            generic = re.findall(r"\[([^\]]+)\]", first_block)
+            if generic:
+                handle = generic[-1]
 
     if entity_type == "person" and handle:
         return await get_person_tool({"person_handle": handle})

--- a/tests/test_save_params_roundtrip.py
+++ b/tests/test_save_params_roundtrip.py
@@ -1,0 +1,72 @@
+"""Round-trip tests for NoteSaveParams and FamilySaveParams.
+
+These models transform user-facing fields into the shapes the Gramps Web API
+expects (StyledText for note text, ChildRef objects for family children) inside
+model_dump(). The FastMCP dispatch layer validates tool arguments into the
+model, calls model_dump(), and the handler then re-validates the resulting
+dict against the same model. That validate -> model_dump -> re-validate cycle
+must be lossless and idempotent, otherwise notes fail to save and family
+children silently disappear. These tests lock that behaviour in.
+"""
+
+from src.gramps_mcp.models.parameters.family_params import FamilySaveParams
+from src.gramps_mcp.models.parameters.note_params import NoteSaveParams
+
+
+class TestNoteSaveParamsRoundTrip:
+    def test_text_dumps_to_styledtext(self):
+        dumped = NoteSaveParams(text="hello", type="Research").model_dump(
+            exclude_none=True
+        )
+        assert dumped["text"] == {"_class": "StyledText", "string": "hello"}
+
+    def test_styledtext_dict_revalidates(self):
+        """Re-validating a dumped model must not raise (the create_note bug)."""
+        first = NoteSaveParams(text="hello", type="Research").model_dump(
+            exclude_none=True
+        )
+        second = NoteSaveParams(**first).model_dump(exclude_none=True)
+        # idempotent: text is still a single-wrapped StyledText, string intact
+        assert second["text"] == {"_class": "StyledText", "string": "hello"}
+
+    def test_field_validator_extracts_string(self):
+        model = NoteSaveParams(
+            text={"_class": "StyledText", "string": "hi"}, type="Research"
+        )
+        assert model.text == "hi"
+
+
+class TestFamilySaveParamsRoundTrip:
+    def test_child_handles_become_child_ref_list(self):
+        dumped = FamilySaveParams(child_handles=["H1", "H2"]).model_dump(
+            exclude_none=True
+        )
+        assert "child_handles" not in dumped
+        assert [c["ref"] for c in dumped["child_ref_list"]] == ["H1", "H2"]
+        assert all(
+            c["_class"] == "ChildRef" and c["frel"] == "Birth" and c["mrel"] == "Birth"
+            for c in dumped["child_ref_list"]
+        )
+
+    def test_children_survive_revalidation(self):
+        """The create_family bug: children dropped on re-validation."""
+        first = FamilySaveParams(
+            father_handle="F", child_handles=["H1", "H2"]
+        ).model_dump(exclude_none=True)
+        second = FamilySaveParams(**first).model_dump(exclude_none=True)
+        assert second["father_handle"] == "F"
+        assert [c["ref"] for c in second["child_ref_list"]] == ["H1", "H2"]
+
+    def test_child_handles_dedupe_against_explicit_refs(self):
+        dumped = FamilySaveParams(
+            child_handles=["H1", "H3"],
+            child_ref_list=[
+                {"_class": "ChildRef", "ref": "H1", "frel": "Birth", "mrel": "Birth"}
+            ],
+        ).model_dump(exclude_none=True)
+        assert [c["ref"] for c in dumped["child_ref_list"]] == ["H1", "H3"]
+
+    def test_no_children_adds_nothing(self):
+        dumped = FamilySaveParams(father_handle="F").model_dump(exclude_none=True)
+        assert "child_ref_list" not in dumped
+        assert "child_handles" not in dumped


### PR DESCRIPTION
## Summary

Four tool handlers either errored on every call or returned success while silently
persisting nothing. Three are shape mismatches between the Pydantic save-models and
what the Gramps Web API expects/returns; one works around a Gramps Web API 500 on the
`/notes` endpoint. Each fix is a separate commit so they can be reviewed or cherry-picked
independently.

All four were found and verified against a live Gramps Web API instance (a real tree),
and the two model fixes are covered by new pure round-trip tests.

## Fixes

### 1. `create_note` / `update_note` failed on every call
`NoteSaveParams.model_dump()` converts `text` (str) into a StyledText dict for the API.
The FastMCP dispatch validates arguments into the model, calls `model_dump()`, then the
handler re-validates the resulting dict against the same model — feeding a StyledText
**dict** back into the `text: str` field:

```
1 validation error for NoteSaveParams
text: Input should be a valid string [type=string_type, input_value={'_class': 'StyledText', ...}]
```

**Fix:** a `field_validator(mode="before")` that normalizes a StyledText dict back to its
string, making the validate → dump → validate round-trip idempotent while keeping the
tool's input schema a plain string. *(Also unblocks note updates, which go through the same
path.)*

### 2. `create_family` silently dropped children
`FamilySaveParams` sent `child_handles` (a list of person handles) as-is, but Gramps stores
children as `child_ref_list` entries: `{"_class": "ChildRef", "ref": <handle>, "frel":
"Birth", "mrel": "Birth"}`. The unknown `child_handles` key was ignored — the family saved,
but with no children.

**Fix:** a `model_dump()` override converts `child_handles` → `child_ref_list`, plus a
declared `child_ref_list` field so the FastMCP validate → dump → re-validate round-trip
preserves it (otherwise it's dropped as an unknown key — the same class of bug as #1).
Gramps maintains the reciprocal `parent_family_list` on each child automatically.

### 3. `find_type(note, ...)` always returned "Server error"
Any `gql` query against the Gramps Web API `/notes` endpoint returns HTTP 500 (other entity
types are fine); it fails even for ids that don't exist, ruling out a data problem.

**Fix:** for notes, skip the crashing `gql` param — fetch notes unfiltered (the endpoint
works without `gql`) and filter client-side over a supported subset: `field =/==/!= "value"`
and `"substr" in field`, combined with `and`. Unparseable filters return a clear message
rather than a 500. *(This works around what looks like an upstream Gramps Web API bug; happy
to file that separately if useful.)*

### 4. `get_type(person|family, ...)` failed with "Record not found" / "unhashable type: 'slice'"
Two layers:
- The handle was scraped from formatted search text with a greedy first-`[...]` regex, which
  grabbed bracketed name tokens like `[Unknown]` instead of the hex handle → "Record not
  found". Now matches hex-shaped handles, falling back to the last bracketed token.
- The person/family detail handlers sliced `note.get("text")[:50]` where `text` is a
  StyledText dict → `unhashable type: 'slice'` for any record with an attached note. Now
  extracts the `string` value (and normalizes a dict note `type`) before slicing.

## Testing

- `tests/test_save_params_roundtrip.py` — new pure tests for the note and family round-trips
  (no API needed). They fail on `main` and pass with these fixes.
- All four behaviors verified end-to-end against a live Gramps Web instance: notes create /
  update / search, family create with children (both `child_ref_list` and the child's
  `parent_family_list` populated), and `get_type` for a person with an attached note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
